### PR TITLE
Updated KeychainAccess to 4.1.0

### DIFF
--- a/AzureAuth.podspec
+++ b/AzureAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = 'AzureAuth'
-  s.version       = '0.5.0'
+  s.version       = '0.5.1'
   s.summary       = 'Microsoft Azure App Service Auth client SDK for iOS.'
 
   s.description   = 'Microsoft Azure App Service Auth client SDK for iOS, macOS, watchOS, tvOS.'

--- a/AzureCore.podspec
+++ b/AzureCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = 'AzureCore'
-  s.version       = '0.5.0'
+  s.version       = '0.5.1'
   s.summary       = 'Microsoft Azure client SDKs for iOS.'
 
   s.description   = 'Microsoft Azure client SDKs for iOS, macOS, watchOS, tvOS.'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => 'https://github.com/Azure/Azure.iOS.git', :tag => "v#{s.version}" }
 
   s.dependency 'Willow', '~> 5.2'
-  s.dependency 'KeychainAccess', '~> 3.2'
+  s.dependency 'KeychainAccess', '~> 4.1.0'
 
   s.swift_version = '5.0'
 

--- a/AzureData.podspec
+++ b/AzureData.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = 'AzureData'
-  s.version       = '0.5.0'
+  s.version       = '0.5.1'
   s.summary       = 'Microsoft Azure Cosmos DB client SDK for iOS.'
 
   s.description   = 'Microsoft Azure Cosmos DB client SDK for iOS, macOS, watchOS, tvOS.'

--- a/AzureMobile.podspec
+++ b/AzureMobile.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = 'AzureMobile'
-  s.version       = '0.5.0'
+  s.version       = '0.5.1'
   s.summary       = 'Microsoft Azure client SDK for iOS.'
 
   s.description   = 'Microsoft Azure client SDK for iOS, macOS, watchOS, tvOS.'

--- a/AzurePush.podspec
+++ b/AzurePush.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = 'AzurePush'
-  s.version       = '0.5.0'
+  s.version       = '0.5.1'
   s.summary       = 'Microsoft Azure Notification Hubs client SDK for iOS.'
 
   s.description   = 'Microsoft Azure Notification Hubs client SDK for iOS, macOS, watchOS, tvOS.'

--- a/AzureStorage.podspec
+++ b/AzureStorage.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = 'AzureStorage'
-  s.version       = '0.5.0'
+  s.version       = '0.5.1'
   s.summary       = 'Microsoft Azure Storage client SDK for iOS.'
 
   s.description   = 'Microsoft Azure Storage client SDK for iOS, macOS, watchOS, tvOS.'


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Changes Proposed in this pull request:
- This PR updates the KeychainAccess to the lasted version (4.1.0) to fix compilation issues in applications targeting macOS Catalina. 
