### PR TITLE
Disable CI builds on feature branches.

### DIFF
--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -16,7 +16,6 @@ trigger:
   branches:
     include:
       - master
-      - feature/*
       - hotfix/*
       - release/*
       - dev # TEMPORARY!

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -16,7 +16,6 @@ trigger:
   branches:
     include:
       - master
-      - feature/*
       - hotfix/*
       - release/*
       - dev # TEMPORARY!

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -16,7 +16,6 @@ trigger:
   branches:
     include:
       - master
-      - feature/*
       - hotfix/*
       - release/*
       - dev # TEMPORARY!

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -16,7 +16,6 @@ trigger:
   branches:
     include:
       - master
-      - feature/*
       - hotfix/*
       - release/*
       - dev # TEMPORARY!

--- a/sdk/textanalytics/ci.yml
+++ b/sdk/textanalytics/ci.yml
@@ -16,7 +16,6 @@ trigger:
   branches:
     include:
       - master
-      - feature/*
       - hotfix/*
       - release/*
       - dev # TEMPORARY!


### PR DESCRIPTION
This PR disables CI builds on feature branches. One of the patterns that we've seen lately is small teams that work on a feature branch doing merges from master (instead of a rebase). Because we have multiple pipelines in the repo many of those pipelines will trigger because of the scope of the changes that have been merged in, causing a build storm.

By disabling CI builds on feature branches we can mitigate that, at the expense of CI feedback on the feature branch. Builds for PRs to that feature branch would still work however.