### PR TITLE
Refactor test names

### DIFF
--- a/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.xcodeproj/project.pbxproj
+++ b/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.xcodeproj/project.pbxproj
@@ -556,7 +556,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = UBF8T346G9;
-				INFOPLIST_FILE = AzureSDKDemoSwiftTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -577,7 +577,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = UBF8T346G9;
-				INFOPLIST_FILE = AzureSDKDemoSwiftTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/sdk/core/AzureCore/Tests/CollectionsTests.swift
+++ b/sdk/core/AzureCore/Tests/CollectionsTests.swift
@@ -51,7 +51,7 @@ class CollectionsTests: XCTestCase {
     }
 
     /// Test that authors can simply use the default PagedCodingKeys if the service fits the Azure standard.
-    func test_PagedCollection_WorksWithDefaultCodingKeys() {
+    func test_PagedCollection_WithDefaultCodingKeys_Inits() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),
@@ -88,7 +88,7 @@ class CollectionsTests: XCTestCase {
     }
 
     /// Test that authors can customize the PagedCodingKeys provided they fit the standard structure.
-    func test_PagedCollection_WorksWithCustomCodingKeys() {
+    func test_PagedCollection_WithCustomCodingKeys_Inits() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),

--- a/sdk/core/AzureCore/Tests/CollectionsTests.swift
+++ b/sdk/core/AzureCore/Tests/CollectionsTests.swift
@@ -51,7 +51,7 @@ class CollectionsTests: XCTestCase {
     }
 
     /// Test that authors can simply use the default PagedCodingKeys if the service fits the Azure standard.
-    func testPagedCollectionDefaults() {
+    func test_PagedCollection_WorksWithDefaultCodingKeys() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),
@@ -88,7 +88,7 @@ class CollectionsTests: XCTestCase {
     }
 
     /// Test that authors can customize the PagedCodingKeys provided they fit the standard structure.
-    func testPagedCollectionCustom() {
+    func test_PagedCollection_WorksWithCustomCodingKeys() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),
@@ -115,7 +115,7 @@ class CollectionsTests: XCTestCase {
         XCTAssertEqual(paged.continuationToken, "token")
     }
 
-    func testPagedCollectionPerItemIteration() {
+    func test_PagedCollection_CanIteratePerItem() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),

--- a/sdk/core/AzureCore/Tests/HTTPRequestTests.swift
+++ b/sdk/core/AzureCore/Tests/HTTPRequestTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 class HttpRequestTests: XCTestCase {
 
-    func testHttpRequest() {
+    func test_HttpRequest_UpdatesQueryString() {
         let headers = HTTPHeaders()
         let httpRequest = HTTPRequest(
             method: .post, url: "https://www.test.com?a=1&b=2", queryParams: [:], headers: headers)
@@ -48,7 +48,7 @@ class HttpRequestTests: XCTestCase {
         XCTAssertEqual(queryItems?["c"], "3", "Update failed to add new value.")
     }
 
-    func testHttpHeaders() {
+    func test_HttpHeaders_CanByModifiedByStringOrEnumKey() {
         // ensure headers can be added by string or enum key
         var headers = HTTPHeaders()
         headers[.accept] = "json"

--- a/sdk/core/AzureCore/Tests/HTTPRequestTests.swift
+++ b/sdk/core/AzureCore/Tests/HTTPRequestTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 class HttpRequestTests: XCTestCase {
 
-    func test_HttpRequest_UpdatesQueryString() {
+    func test_HttpRequest_WithQueryString_UpdatesQueryString() {
         let headers = HTTPHeaders()
         let httpRequest = HTTPRequest(
             method: .post, url: "https://www.test.com?a=1&b=2", queryParams: [:], headers: headers)
@@ -48,7 +48,7 @@ class HttpRequestTests: XCTestCase {
         XCTAssertEqual(queryItems?["c"], "3", "Update failed to add new value.")
     }
 
-    func test_HttpHeaders_CanByModifiedByStringOrEnumKey() {
+    func test_HttpHeaders_WithEnumOrStringKey_CanBeModified() {
         // ensure headers can be added by string or enum key
         var headers = HTTPHeaders()
         headers[.accept] = "json"

--- a/sdk/core/AzureCore/Tests/PipelineRequestTests.swift
+++ b/sdk/core/AzureCore/Tests/PipelineRequestTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 class PipelineRequestTests: XCTestCase {
 
-    func testPipelineRequestCopy() {
+    func test_PipelineRequest_CanBeCopied() {
         let logger = ClientLoggers.default()
         let httpRequest = HTTPRequest(method: .get, url: "https://www.contoso.com", queryParams: [:], headers: HTTPHeaders())
         let originalRequest = PipelineRequest(request: httpRequest, logger: logger)
@@ -39,7 +39,7 @@ class PipelineRequestTests: XCTestCase {
         XCTAssertFalse(originalRequest.httpRequest === copyRequest.httpRequest)
     }
 
-    func testPipelineContext() {
+    func test_PipelineContext_CanAddAndAccessValues() {
         let logger = ClientLoggers.default()
         let httpRequest = HTTPRequest(
             method: .get, url: "https://www.contoso.com", queryParams: [:], headers: HTTPHeaders())

--- a/sdk/core/AzureCore/Tests/PipelineTests.swift
+++ b/sdk/core/AzureCore/Tests/PipelineTests.swift
@@ -43,7 +43,7 @@ class PipelineTests: XCTestCase {
         return client
     }
 
-    func test_HTTPRequest_CanBeCreated() {
+    func test_HTTPRequest_Inits() {
         let client = createPipelineClient()
         let headers: HTTPHeaders = [
             "headerParam": "myHeaderParam"

--- a/sdk/core/AzureCore/Tests/PipelineTests.swift
+++ b/sdk/core/AzureCore/Tests/PipelineTests.swift
@@ -43,7 +43,7 @@ class PipelineTests: XCTestCase {
         return client
     }
 
-    func testPipelineClientRequest() {
+    func test_HTTPRequest_CanBeCreated() {
         let client = createPipelineClient()
         let headers: HTTPHeaders = [
             "headerParam": "myHeaderParam"
@@ -55,7 +55,7 @@ class PipelineTests: XCTestCase {
         XCTAssertEqual(request.headers, headers)
     }
 
-    func testPipelineClientFormat() {
+    func test_PipelineClient_CanFormatUrl() {
         let client = createPipelineClient()
         let url = client.url(forTemplate: "{a}/{b}/test", withKwargs: [
             "a": "cat",
@@ -64,7 +64,7 @@ class PipelineTests: XCTestCase {
         XCTAssertEqual(url, "\(client.baseUrl)cat/hat/test")
     }
 
-    func testPipelineClientRun() {
+    func test_PipelineClient_CanRun() {
         let client = createPipelineClient()
         let request = HTTPRequest(
             method: .get, url: "", queryParams: [:], headers: [:])
@@ -84,7 +84,7 @@ class PipelineTests: XCTestCase {
         wait(for: [didFinishRun], timeout: 2.0, enforceOrder: true)
     }
 
-    func testPipelineClientLogError() {
+    func test_PipelineClient_CanLogError() {
         XCTFail("TODO: Implement test.")
     }
 }

--- a/sdk/core/AzureCore/Tests/UtilTests.swift
+++ b/sdk/core/AzureCore/Tests/UtilTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 class RegexUtilTests: XCTestCase {
 
-    func test_RegexUtil_HandlesMatchingString() {
+    func test_RegexUtil_WithMatchingString_ReturnsMatch() {
         let regex = NSRegularExpression("^(application|text)/([0-9a-z+.]+)?json$")
         let goodString = "application/json"
 
@@ -39,7 +39,7 @@ class RegexUtilTests: XCTestCase {
         XCTAssertEqual(result, goodString)
     }
 
-    func test_RegexUtil_HandlesNonMatchingString() {
+    func test_RegexUtil_WithNonMatchingString_ReturnsNil() {
         let regex = NSRegularExpression("^(application|text)/([0-9a-z+.]+)?json$")
         let badString = "application/xml"
 
@@ -48,7 +48,7 @@ class RegexUtilTests: XCTestCase {
         XCTAssertNil(regex.firstMatch(in: badString))
     }
 
-    func test_DateUtil_SupportsRFC1123() {
+    func test_DateUtil_WithRFC1123String_ConvertsToDate() {
         let rfc1123String = "Jan, 02 2020 07:12:34 GMT"
         let date = rfc1123String.rfc1123Date
 
@@ -72,40 +72,69 @@ class RegexUtilTests: XCTestCase {
         XCTAssertEqual(dateComponents.timeZone, TimeZone.init(abbreviation: "GMT"))
     }
 
-    func test_StringUtil_AsBoolOutputsBoolOrNil() {
+    func test_StringUtil_WithBoolString_OutputsBool() {
         let headers: HTTPHeaders = [
             "string": "test",
             "bool": "true"
         ]
         XCTAssertEqual(headers["bool"].asBool, true)
+    }
+
+    func test_StringUtil_WithNonBoolString_OutputsNil() {
+        let headers: HTTPHeaders = [
+            "string": "test",
+            "bool": "true"
+        ]
         XCTAssertNil(headers["string"].asBool)
     }
 
-    func test_StringUtil_AsIntOutputsIntOrNil() {
+    func test_StringUtil_WithIntString_OutputsInt() {
         let headers: HTTPHeaders = [
             "bool": "true",
             "int": "22"
         ]
         XCTAssertEqual(headers["int"].asInt, 22)
+    }
+
+    func test_StringUtil_WithNonIntString_OutputsNil() {
+        let headers: HTTPHeaders = [
+            "bool": "true",
+            "int": "22"
+        ]
         XCTAssertNil(headers["bool"].asInt)
     }
 
-    func test_StringUtil_AsEnumOutputsEnumOrNil() {
+    func test_StringUtil_WithEnumString_OutputsEnum() {
         let headers: HTTPHeaders = [
             "int": "22",
             "enum": "Accept"
         ]
         XCTAssertEqual(headers["enum"].asEnum(HTTPHeader.self), HTTPHeader.accept)
+    }
+
+    func test_StringUtil_WithNonEnumString_OutputsNil() {
+        let headers: HTTPHeaders = [
+            "int": "22",
+            "enum": "Accept"
+        ]
         XCTAssertNil(headers["int"].asEnum(HTTPHeader.self))
     }
 
-    func test_StringUtil_AsDateOutputsDateOrNil() {
+    func test_StringUtil_WithDateString_OutputsDate() {
         let dateString = "Jan, 02 2020 07:12:34 GMT"
         let headers: HTTPHeaders = [
             "bool": "true",
             "date": dateString
         ]
         XCTAssertEqual(headers["date"].asDate, dateString.rfc1123Date)
+    }
+
+    func test_StringUtil_WithNonDateString_OutputsNil() {
+        let dateString = "Jan, 02 2020 07:12:34 GMT"
+        let headers: HTTPHeaders = [
+            "bool": "true",
+            "date": dateString
+        ]
         XCTAssertNil(headers["bool"].asDate)
     }
 }

--- a/sdk/core/AzureCore/Tests/UtilTests.swift
+++ b/sdk/core/AzureCore/Tests/UtilTests.swift
@@ -29,22 +29,26 @@ import XCTest
 
 class RegexUtilTests: XCTestCase {
 
-    func testRegexUtil() {
+    func test_RegexUtil_HandlesMatchingString() {
         let regex = NSRegularExpression("^(application|text)/([0-9a-z+.]+)?json$")
         let goodString = "application/json"
-        let badString = "application/xml"
 
         // test a good string
         let result = regex.firstMatch(in: goodString)
         XCTAssertTrue(regex.hasMatch(in: goodString))
         XCTAssertEqual(result, goodString)
+    }
+
+    func test_RegexUtil_HandlesNonMatchingString() {
+        let regex = NSRegularExpression("^(application|text)/([0-9a-z+.]+)?json$")
+        let badString = "application/xml"
 
         // test a bad string
         XCTAssertFalse(regex.hasMatch(in: badString))
         XCTAssertNil(regex.firstMatch(in: badString))
     }
 
-    func testDateUtil() {
+    func test_DateUtil_SupportsRFC1123() {
         let rfc1123String = "Jan, 02 2020 07:12:34 GMT"
         let date = rfc1123String.rfc1123Date
 
@@ -68,30 +72,39 @@ class RegexUtilTests: XCTestCase {
         XCTAssertEqual(dateComponents.timeZone, TimeZone.init(abbreviation: "GMT"))
     }
 
-    func testStringUtil() {
-        let dateString = "Jan, 02 2020 07:12:34 GMT"
+    func test_StringUtil_AsBoolOutputsBoolOrNil() {
         let headers: HTTPHeaders = [
             "string": "test",
-            "bool": "true",
-            "int": "22",
-            "date": dateString,
-            "enum": "Accept"
+            "bool": "true"
         ]
-        XCTAssertEqual(headers["string"], "test")
-
-        // test asBool
         XCTAssertEqual(headers["bool"].asBool, true)
         XCTAssertNil(headers["string"].asBool)
+    }
 
-        // test asInt
+    func test_StringUtil_AsIntOutputsIntOrNil() {
+        let headers: HTTPHeaders = [
+            "bool": "true",
+            "int": "22"
+        ]
         XCTAssertEqual(headers["int"].asInt, 22)
         XCTAssertNil(headers["bool"].asInt)
+    }
 
-        // test asEnum
+    func test_StringUtil_AsEnumOutputsEnumOrNil() {
+        let headers: HTTPHeaders = [
+            "int": "22",
+            "enum": "Accept"
+        ]
         XCTAssertEqual(headers["enum"].asEnum(HTTPHeader.self), HTTPHeader.accept)
         XCTAssertNil(headers["int"].asEnum(HTTPHeader.self))
+    }
 
-        // test asDate
+    func test_StringUtil_AsDateOutputsDateOrNil() {
+        let dateString = "Jan, 02 2020 07:12:34 GMT"
+        let headers: HTTPHeaders = [
+            "bool": "true",
+            "date": dateString
+        ]
         XCTAssertEqual(headers["date"].asDate, dateString.rfc1123Date)
         XCTAssertNil(headers["bool"].asDate)
     }

--- a/sdk/core/AzureCore/Tests/XMLModelTests.swift
+++ b/sdk/core/AzureCore/Tests/XMLModelTests.swift
@@ -220,7 +220,7 @@ class XMLModelTests: XCTestCase {
     }
 
     /// Test that an XML Model can be inferred from an object structure.
-    func test_XMLModel_CanInferStructure() {
+    func test_XMLModel_WithoutXMLMap_CanBeCreated() {
         for name in ["thing1", "thing2"] {
             let decodePolicy = ContentDecodePolicy()
             decodePolicy.logger = ClientLoggers.default()
@@ -236,7 +236,7 @@ class XMLModelTests: XCTestCase {
     }
 
     /// Test that an XML Model can be created with a custom XML map.
-    func test_XMLModel_CanBuildMappedStructure() {
+    func test_XMLModel_WithXMLMap_CanBeCreated() {
         for name in ["thing1", "thing2"] {
             let decodePolicy = ContentDecodePolicy()
             decodePolicy.delegate?.xmlMap = MappedThing.xmlMap()
@@ -253,7 +253,7 @@ class XMLModelTests: XCTestCase {
     }
 
     /// Test that an XML Model can be constructed that works with the PagedCollection type.
-    func test_XMLModel_CanBuildPagedStructure() {
+    func test_XMLModel_WithPagedCollectionAndXMLMap_CanBeCreated() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),

--- a/sdk/core/AzureCore/Tests/XMLModelTests.swift
+++ b/sdk/core/AzureCore/Tests/XMLModelTests.swift
@@ -220,7 +220,7 @@ class XMLModelTests: XCTestCase {
     }
 
     /// Test that an XML Model can be inferred from an object structure.
-    func testXMLModelInferredStructure() {
+    func test_XMLModel_CanInferStructure() {
         for name in ["thing1", "thing2"] {
             let decodePolicy = ContentDecodePolicy()
             decodePolicy.logger = ClientLoggers.default()
@@ -236,7 +236,7 @@ class XMLModelTests: XCTestCase {
     }
 
     /// Test that an XML Model can be created with a custom XML map.
-    func testXMLModelMappedStructure() {
+    func test_XMLModel_CanBuildMappedStructure() {
         for name in ["thing1", "thing2"] {
             let decodePolicy = ContentDecodePolicy()
             decodePolicy.delegate?.xmlMap = MappedThing.xmlMap()
@@ -253,7 +253,7 @@ class XMLModelTests: XCTestCase {
     }
 
     /// Test that an XML Model can be constructed that works with the PagedCollection type.
-    func testXMLModelPagedStructure() {
+    func test_XMLModel_CanBuildPagedStructure() {
         let client = PipelineClient(
             baseUrl: "http://www.microsoft.com",
             transport: URLSessionTransport(),


### PR DESCRIPTION
Refactors test names to follow the `test_[thing]_[expectation]` pattern in #184