### PR TITLE
Update app bundle identifier.

### DIFF
--- a/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.entitlements
+++ b/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.azure.demo.AzureSDKDemoSwifty</string>
+		<string>$(AppIdentifierPrefix)com.azure.examples.AzureSDKDemoSwifty</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.MSALTestApp</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
 	</array>

--- a/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.xcodeproj/project.pbxproj
+++ b/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.azure.demo.AzureSDKDemoSwiftTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.azure.examples.AzureSDKDemoSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -583,7 +583,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.azure.demo.AzureSDKDemoSwiftTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.azure.examples.AzureSDKDemoSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -40,7 +40,7 @@ struct AppConstants {
 
     static let clientId = "6f2c62dd-d6b2-444a-8dff-c64380e7ac76"
 
-    static let redirectUri = "msauth.com.azure.demo.AzureSDKDemoSwifty://auth"
+    static let redirectUri = "msauth.com.azure.examples.AzureSDKDemoSwifty://auth"
 
     static let authority = "https://login.microsoftonline.com/7e6c9611-413e-47e4-a054-a389854dd732"
 }

--- a/examples/AzureSDKDemoSwift/Source/Supporting Files/Info.plist
+++ b/examples/AzureSDKDemoSwift/Source/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>msauth.com.azure.demo.AzureSDKDemoSwifty</string>
+				<string>msauth.com.azure.examples.AzureSDKDemoSwifty</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
The recent update to the app bundle identifiers broke the auth in the demo app. This fixes up the necessary references.