### PR TITLE
Enable module stability when building

### DIFF
--- a/sdk/appconfiguration/AzureAppConfiguration/AzureAppConfiguration.xcodeproj/project.pbxproj
+++ b/sdk/appconfiguration/AzureAppConfiguration/AzureAppConfiguration.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -458,6 +459,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;

--- a/sdk/cognitiveservices/AzureCSComputerVision/AzureCSComputerVision.xcodeproj/project.pbxproj
+++ b/sdk/cognitiveservices/AzureCSComputerVision/AzureCSComputerVision.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -434,6 +435,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;

--- a/sdk/core/AzureCore/AzureCore.xcodeproj/project.pbxproj
+++ b/sdk/core/AzureCore/AzureCore.xcodeproj/project.pbxproj
@@ -820,6 +820,7 @@
 			baseConfigurationReference = 997D1939CDC5E0A7A153F6DF /* Pods-AzureCore.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -852,6 +853,7 @@
 			baseConfigurationReference = 5CBF50632171488DE1372EB1 /* Pods-AzureCore.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;

--- a/sdk/storage/AzureStorageBlob/AzureStorageBlob.xcodeproj/project.pbxproj
+++ b/sdk/storage/AzureStorageBlob/AzureStorageBlob.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -516,6 +517,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/sdk/textanalytics/AzureCSTextAnalytics/AzureCSTextAnalytics.xcodeproj/project.pbxproj
+++ b/sdk/textanalytics/AzureCSTextAnalytics/AzureCSTextAnalytics.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -430,6 +431,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
Relates to: #174 

This will produce a .swiftinterface file for each module. This file is used by Swift 5.1's module stability feature to enable binary modules to be used with all newer compilers.

Another benefit is that the .swiftinterface file is text-based and we can easily diff them to compare the differences in the public interface between builds. It even includes the list of imports in the project which we could analyze to alert when a new dependency is introduced.