### PR TITLE
Specify path of config files in swiftformat

### DIFF
--- a/Scripts/swiftlint.sh
+++ b/Scripts/swiftlint.sh
@@ -1,19 +1,20 @@
 #!/bin/sh
 
 #  swiftlint.sh
+REPO_ROOT=$(dirname "$0")/..
 
 if which swiftformat >/dev/null; then
     echo "Formatting Swift files at paths $@"
-    swiftformat --quiet $@
+    swiftformat --quiet --config "$REPO_ROOT/.swiftformat" $@
 else
     echo "warning: SwiftFormat not installed. Download from https://github.com/nicklockwood/SwiftFormat"
 fi
 
 if which swiftlint >/dev/null; then
     echo "Correcting Swift files at paths $@"
-    swiftlint autocorrect --quiet --path $@
+    swiftlint autocorrect --quiet --config "$REPO_ROOT/.swiftlint.yml" --path $@
     echo "Linting Swift files at paths $@"
-    swiftlint lint --quiet --path $@
+    swiftlint lint --quiet --config "$REPO_ROOT/.swiftlint.yml" --path $@
 else
     echo "warning: SwiftLint not installed. Download from https://github.com/realm/SwiftLint"
 fi


### PR DESCRIPTION
This fixes an issue where running the script from Xcode could result in the tools not being able to locate their config files correctly and would apply the default ruleset instead.