### PR TITLE
Keep a registry of restoration ID -> Client inside the TransferManager

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -206,7 +206,6 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
                 blob: blobName,
                 fromContainer: containerName,
                 toFile: destination,
-                withRestorationId: "download",
                 withOptions: options
             ) as? BlobTransfer {
                 downloadMap[indexPath] = transfer

--- a/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
@@ -227,7 +227,6 @@ extension BlobUploadViewController: UICollectionViewDelegate, UICollectionViewDa
                 toContainer: containerName,
                 asBlob: blobName,
                 properties: properties,
-                withRestorationId: "upload",
                 withOptions: options
             ) {
                 data.transfer = transfer as? BlobTransfer

--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -110,6 +110,7 @@ struct AppState {
             client = StorageBlobClient(
                 accountUrl: AppConstants.storageAccountUrl,
                 credential: credential,
+                withRestorationId: "AzureSDKDemoSwift",
                 withOptions: options
             )
             AppState.internalBlobClient = client

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataClass.swift
@@ -193,8 +193,8 @@ public class BlobTransfer: NSManagedObject, TransferImpl {
     }
 }
 
-extension BlobTransfer {
-    internal static func with(
+internal extension BlobTransfer {
+    static func with(
         context: NSManagedObjectContext,
         clientRestorationId: String,
         source: URL,

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
@@ -33,7 +33,11 @@ extension BlobTransfer {
         return NSFetchRequest<BlobTransfer>(entityName: "BlobTransfer")
     }
 
-    @NSManaged internal var clientRestorationId: String
+    /// An identifier used to associate this transfer with the client that created it. When a transfer is reloaded from
+    /// disk (e.g. after an application crash), it can only be resumed once a client with the same `restorationId` has
+    /// been initialized. Attempting to resume it without previously initializing such a client will cause the transfer
+    /// to transition to the `failed` state.
+    @NSManaged public var clientRestorationId: String
     /// The destionation of the transfer. For uploads, this is the blob URL where the file is being uploaded. For
     /// downloads, this is the local path on the device to which the blob is being downloaded.
     @NSManaged public internal(set) var destination: URL?

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
@@ -64,16 +64,16 @@ extension BlobTransfer {
 
 // MARK: Generated accessors for blocks
 
-extension BlobTransfer {
+internal extension BlobTransfer {
     @objc(addBlocksObject:)
-    @NSManaged internal func addToBlocks(_ value: BlockTransfer)
+    @NSManaged func addToBlocks(_ value: BlockTransfer)
 
     @objc(removeBlocksObject:)
-    @NSManaged internal func removeFromBlocks(_ value: BlockTransfer)
+    @NSManaged func removeFromBlocks(_ value: BlockTransfer)
 
     @objc(addBlocks:)
-    @NSManaged public func addToBlocks(_ values: NSSet)
+    @NSManaged func addToBlocks(_ values: NSSet)
 
     @objc(removeBlocks:)
-    @NSManaged public func removeFromBlocks(_ values: NSSet)
+    @NSManaged func removeFromBlocks(_ values: NSSet)
 }

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataClass.swift
@@ -29,19 +29,19 @@ import CoreData
 import Foundation
 
 internal class BlockTransfer: NSManagedObject, TransferImpl {
-    public var operation: ResumableOperation?
+    internal var operation: ResumableOperation?
 
     public var debugString: String {
         return "\t\tTransfer \(type(of: self)) \(hash): Status \(state.label)"
     }
 
-    public var clientRestorationId: String {
+    internal var clientRestorationId: String {
         return parent.clientRestorationId
     }
 }
 
-extension BlockTransfer {
-    internal static func with(
+internal extension BlockTransfer {
+    static func with(
         context: NSManagedObjectContext,
         id: UUID? = nil,
         startRange: Int64,

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataClass.swift
@@ -34,6 +34,10 @@ internal class BlockTransfer: NSManagedObject, TransferImpl {
     public var debugString: String {
         return "\t\tTransfer \(type(of: self)) \(hash): Status \(state.label)"
     }
+
+    public var clientRestorationId: String {
+        return parent.clientRestorationId
+    }
 }
 
 extension BlockTransfer {
@@ -42,7 +46,7 @@ extension BlockTransfer {
         id: UUID? = nil,
         startRange: Int64,
         endRange: Int64,
-        parent: BlobTransfer? = nil
+        parent: BlobTransfer
     ) -> BlockTransfer {
         guard let transfer = NSEntityDescription.insertNewObject(
             forEntityName: "BlockTransfer",

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataProperties.swift
@@ -33,9 +33,9 @@ extension BlockTransfer {
         return NSFetchRequest<BlockTransfer>(entityName: "BlockTransfer")
     }
 
-    @NSManaged public var endRange: Int64
-    @NSManaged public var id: UUID
-    @NSManaged public var rawState: Int16
-    @NSManaged public var startRange: Int64
-    @NSManaged public var parent: BlobTransfer
+    @NSManaged internal var endRange: Int64
+    @NSManaged internal var id: UUID
+    @NSManaged internal var rawState: Int16
+    @NSManaged internal var startRange: Int64
+    @NSManaged internal var parent: BlobTransfer
 }

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlockTransfer+CoreDataProperties.swift
@@ -37,5 +37,5 @@ extension BlockTransfer {
     @NSManaged public var id: UUID
     @NSManaged public var rawState: Int16
     @NSManaged public var startRange: Int64
-    @NSManaged public var parent: BlobTransfer?
+    @NSManaged public var parent: BlobTransfer
 }

--- a/sdk/storage/AzureStorageBlob/Source/Data/MultiBlobTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/MultiBlobTransfer+CoreDataClass.swift
@@ -47,6 +47,15 @@ internal class MultiBlobTransfer: NSManagedObject, TransferImpl {
         return string
     }
 
+    public var clientRestorationId: String {
+        guard let restorationId = transfers.first?.clientRestorationId else {
+            // Return a string that will never match a client. This transfer will transition to the 'failed' state.
+            assertionFailure("Unable to retrieve clientRestorationId, MultiBlobTransfer object has no children.")
+            return "x-ms-failed"
+        }
+        return restorationId
+    }
+
     public var state: TransferState {
         get {
             let currState = TransferState(rawValue: rawState)!

--- a/sdk/storage/AzureStorageBlob/Source/Data/MultiBlobTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/MultiBlobTransfer+CoreDataClass.swift
@@ -32,9 +32,9 @@ import Foundation
 internal class MultiBlobTransfer: NSManagedObject, TransferImpl {
     // MARK: Properties
 
-    public var operation: ResumableOperation?
+    internal var operation: ResumableOperation?
 
-    public var transfers: [BlobTransfer] {
+    internal var transfers: [BlobTransfer] {
         guard let blobSet = blobs else { return [BlobTransfer]() }
         return blobSet.map { $0 as? BlobTransfer }.filter { $0 != nil }.map { $0! }
     }
@@ -47,7 +47,7 @@ internal class MultiBlobTransfer: NSManagedObject, TransferImpl {
         return string
     }
 
-    public var clientRestorationId: String {
+    internal var clientRestorationId: String {
         guard let restorationId = transfers.first?.clientRestorationId else {
             // Return a string that will never match a client. This transfer will transition to the 'failed' state.
             assertionFailure("Unable to retrieve clientRestorationId, MultiBlobTransfer object has no children.")
@@ -56,7 +56,7 @@ internal class MultiBlobTransfer: NSManagedObject, TransferImpl {
         return restorationId
     }
 
-    public var state: TransferState {
+    public internal(set) var state: TransferState {
         get {
             let currState = TransferState(rawValue: rawState)!
             var state = currState
@@ -73,8 +73,8 @@ internal class MultiBlobTransfer: NSManagedObject, TransferImpl {
     }
 }
 
-extension MultiBlobTransfer {
-    internal static func with(context: NSManagedObjectContext) -> MultiBlobTransfer {
+internal extension MultiBlobTransfer {
+    static func with(context: NSManagedObjectContext) -> MultiBlobTransfer {
         guard let transfer = NSEntityDescription.insertNewObject(
             forEntityName: "MultiBlobTransfer",
             into: context

--- a/sdk/storage/AzureStorageBlob/Source/Data/MultiBlobTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/MultiBlobTransfer+CoreDataProperties.swift
@@ -33,24 +33,24 @@ extension MultiBlobTransfer {
         return NSFetchRequest<MultiBlobTransfer>(entityName: "MultiBlobTransfer")
     }
 
-    @NSManaged public var id: UUID
-    @NSManaged public var rawState: Int16
-    @NSManaged public var totalBlobs: Int64
-    @NSManaged public var blobs: NSSet?
+    @NSManaged internal var id: UUID
+    @NSManaged internal var rawState: Int16
+    @NSManaged internal var totalBlobs: Int64
+    @NSManaged internal var blobs: NSSet?
 }
 
 // MARK: Generated accessors for blobs
 
-extension MultiBlobTransfer {
+internal extension MultiBlobTransfer {
     @objc(addBlobsObject:)
-    @NSManaged public func addToBlobs(_ value: BlobTransfer)
+    @NSManaged func addToBlobs(_ value: BlobTransfer)
 
     @objc(removeBlobsObject:)
-    @NSManaged public func removeFromBlobs(_ value: BlobTransfer)
+    @NSManaged func removeFromBlobs(_ value: BlobTransfer)
 
     @objc(addBlobs:)
-    @NSManaged public func addToBlobs(_ values: NSSet)
+    @NSManaged func addToBlobs(_ values: NSSet)
 
     @objc(removeBlobs:)
-    @NSManaged public func removeFromBlobs(_ values: NSSet)
+    @NSManaged func removeFromBlobs(_ values: NSSet)
 }

--- a/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
@@ -61,6 +61,7 @@ public protocol Transfer: AnyObject {
 }
 
 internal protocol TransferImpl: Transfer {
+    var clientRestorationId: String { get }
     var operation: ResumableOperation? { get set }
     var state: TransferState { get set }
     var rawState: Int16 { get set }

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlobDownloadOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlobDownloadOperations.swift
@@ -79,13 +79,13 @@ internal class BlobDownloadInitialOperation: ResumableOperation {
     public override func main() {
         if isCancelled || isPaused { return }
         guard let transfer = self.transfer as? BlockTransfer,
-            let parent = transfer.parent,
-            parent.transferType == .download,
-            let downloader = parent.downloader else {
+            transfer.parent.transferType == .download,
+            let downloader = transfer.parent.downloader else {
             assertionFailure("Preconditions failed for BlobDownloadInitialOperation")
             return
         }
 
+        let parent = transfer.parent
         transfer.state = .inProgress
         parent.state = .inProgress
         delegate?.operation(self, didChangeState: transfer.state)

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlockOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlockOperations.swift
@@ -40,11 +40,11 @@ internal class BlockOperation: ResumableOperation {
     // MARK: Public Methods
 
     public override func main() {
-        guard let transfer = transfer as? BlockTransfer,
-            let parent = transfer.parent else {
+        guard let transfer = transfer as? BlockTransfer else {
             assertionFailure("Precondition failed for BlockOperation.")
             return
         }
+        let parent = transfer.parent
         if isCancelled || isPaused { return }
         transfer.state = .inProgress
         parent.state = .inProgress

--- a/sdk/storage/AzureStorageBlob/Source/Operation/ResumableOperation.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/ResumableOperation.swift
@@ -87,7 +87,7 @@ internal class ResumableOperation: Operation {
     internal func notifyDelegate(withTransfer transfer: Transfer) {
         switch transfer {
         case let transfer as BlockTransfer:
-            if let parent = transfer.parent?.operation?.transfer {
+            if let parent = transfer.parent.operation?.transfer {
                 notifyDelegate(withTransfer: parent)
                 return
             }
@@ -106,7 +106,7 @@ internal class ResumableOperation: Operation {
         // Notify the delegate of the block change AND the parent change.
         // This allows the developer to decide which events to respond to.
         delegate?.operation(self, didChangeState: transfer.state)
-        if let parent = transfer.parent?.operation, let parentState = parent.transfer?.state {
+        if let parent = transfer.parent.operation, let parentState = parent.transfer?.state {
             delegate?.operation(parent, didChangeState: parentState)
         }
     }

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -540,7 +540,10 @@ public final class StorageBlobClient: PipelineClient {
         ///   - name: The name of the blob.
         ///   - container: The name of the container
         /// - Returns: A tuple of (`dirName`, `fileName`)
-        public static func pathComponents(forBlob name: String, inContainer container: String) -> (String, String) {
+        public static func pathComponents(
+            forBlob name: String,
+            inContainer container: String
+        ) -> (dirName: String, fileName: String) {
             var defaultUrlComps = "\(container)/\(name)".split(separator: "/").compactMap { String($0) }
             let baseName = defaultUrlComps.popLast()!
             let dirName = defaultUrlComps.joined(separator: "/")

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -39,20 +39,16 @@ public final class StorageBlobClient: PipelineClient {
     /// Options provided to configure this `StorageBlobClient`.
     public let options: StorageBlobClientOptions
 
-    /// The `TransferDelegate` to inform about transfer events.
+    /// The `TransferDelegate` to inform about events from transfers created by this `StorageBlobClient`.
     public weak var transferDelegate: TransferDelegate?
 
     private static let defaultScopes = [
         "https://storage.azure.com/.default"
     ]
 
-    fileprivate var managing = false
-    fileprivate lazy var manager: TransferManager = {
-        var manager = URLSessionTransferManager.shared
-        manager.delegate = self
-        manager.logger = self.logger
-        return manager
-    }()
+    private var managing = false
+    private let manager: TransferManager = URLSessionTransferManager.shared
+    private let restorationId: String
 
     // MARK: Initializers
 
@@ -60,9 +56,21 @@ public final class StorageBlobClient: PipelineClient {
     /// - Parameters:
     ///   - baseUrl: Base URL for the storage account.
     ///   - authPolicy: An `Authenticating` policy to use for authenticating client requests.
+    ///   - restorationId: An identifier used to associate this client with transfers it creates. When a transfer is
+    ///     reloaded from disk (e.g. after an application crash), it can only be resumed once a client with the same
+    ///     `restorationId` has been initialized. If your application only uses a single `StorageBlobClient`, it is
+    ///     recommended to use a value unique to your application (e.g. "MyApplication"). If your application uses
+    ///     multiple clients with different configurations, use a value unique to both your application and the
+    ///     configuration (e.g. "MyApplication.userClient").
     ///   - options: Options used to configure the client.
-    private init(baseUrl: URL, authPolicy: Authenticating, withOptions options: StorageBlobClientOptions? = nil) {
+    private init(
+        baseUrl: URL,
+        authPolicy: Authenticating,
+        withRestorationId restorationId: String,
+        withOptions options: StorageBlobClientOptions? = nil
+    ) {
         self.options = options ?? StorageBlobClientOptions(apiVersion: ApiVersion.latest.rawValue)
+        self.restorationId = restorationId
         super.init(
             baseUrl: baseUrl,
             transport: URLSessionTransport(),
@@ -79,28 +87,43 @@ public final class StorageBlobClient: PipelineClient {
             ],
             logger: self.options.logger
         )
+        manager.register(client: self, forRestorationId: restorationId)
     }
 
     /// Create a Storage blob data client.
     /// - Parameters:
     ///   - accountUrl: Base URL for the storage account.
     ///   - credential: A `MSALCredential` object used to retrieve authentication tokens.
+    ///   - restorationId: An identifier used to associate this client with transfers it creates. When a transfer is
+    ///     reloaded from disk (e.g. after an application crash), it can only be resumed once a client with the same
+    ///     `restorationId` has been initialized. If your application only uses a single `StorageBlobClient`, it is
+    ///     recommended to use a value unique to your application (e.g. "MyApplication"). If your application uses
+    ///     multiple clients with different configurations, use a value unique to both your application and the
+    ///     configuration (e.g. "MyApplication.userClient").
     ///   - options: Options used to configure the client.
     public convenience init(
         accountUrl: URL,
         credential: MSALCredential,
+        withRestorationId restorationId: String,
         withOptions options: StorageBlobClientOptions? = nil
     ) {
         let authPolicy = BearerTokenCredentialPolicy(credential: credential, scopes: StorageBlobClient.defaultScopes)
-        self.init(baseUrl: accountUrl, authPolicy: authPolicy, withOptions: options)
+        self.init(baseUrl: accountUrl, authPolicy: authPolicy, withRestorationId: restorationId, withOptions: options)
     }
 
     /// Create a Storage blob data client.
     /// - Parameters:
     ///   - credential: A `StorageSASCredential` object used to retrieve the base URL and authentication tokens.
+    ///   - restorationId: An identifier used to associate this client with transfers it creates. When a transfer is
+    ///     reloaded from disk (e.g. after an application crash), it can only be resumed once a client with the same
+    ///     `restorationId` has been initialized. If your application only uses a single `StorageBlobClient`, it is
+    ///     recommended to use a value unique to your application (e.g. "MyApplication"). If your application uses
+    ///     multiple clients with different configurations, use a value unique to both your application and the
+    ///     configuration (e.g. "MyApplication.userClient").
     ///   - options: Options used to configure the client.
     public convenience init(
         credential: StorageSASCredential,
+        withRestorationId restorationId: String,
         withOptions options: StorageBlobClientOptions? = nil
     ) throws {
         guard let blobEndpoint = credential.blobEndpoint else {
@@ -110,17 +133,27 @@ public final class StorageBlobClient: PipelineClient {
             throw AzureError.fileSystem("Unable to resolve account URL from credential.")
         }
         let authPolicy = StorageSASAuthenticationPolicy(credential: credential)
-        self.init(baseUrl: baseUrl, authPolicy: authPolicy, withOptions: options)
+        self.init(baseUrl: baseUrl, authPolicy: authPolicy, withRestorationId: restorationId, withOptions: options)
     }
 
     /// Create a Storage blob data client.
     /// - Parameters:
     ///   - connectionString: Storage account connection string. **WARNING**: Connection strings are inherently insecure
     ///     in a mobile app. Any connection strings used should be read-only and not have write permissions.
+    ///   - restorationId: An identifier used to associate this client with transfers it creates. When a transfer is
+    ///     reloaded from disk (e.g. after an application crash), it can only be resumed once a client with the same
+    ///     `restorationId` has been initialized. If your application only uses a single `StorageBlobClient`, it is
+    ///     recommended to use a value unique to your application (e.g. "MyApplication"). If your application uses
+    ///     multiple clients with different configurations, use a value unique to both your application and the
+    ///     configuration (e.g. "MyApplication.userClient").
     ///   - options: Options used to configure the client.
-    public convenience init(connectionString: String, withOptions options: StorageBlobClientOptions? = nil) throws {
+    public convenience init(
+        connectionString: String,
+        withRestorationId restorationId: String,
+        withOptions options: StorageBlobClientOptions? = nil
+    ) throws {
         let credential = try StorageSASCredential(connectionString: connectionString)
-        try self.init(credential: credential, withOptions: options)
+        try self.init(credential: credential, withRestorationId: restorationId, withOptions: options)
     }
 
     // MARK: Public Client Methods
@@ -386,13 +419,11 @@ public final class StorageBlobClient: PipelineClient {
     ///   - blob: The name of the blob.
     ///   - container: The name of the container.
     ///   - destinationUrl: The URL to a file path on this device.
-    ///   - restorationId: An identifier that it is used to recreate the client and resume an operation.
     ///   - options: A `DownloadBlobOptions` object to control the download operation.
     public func download(
         blob: String,
         fromContainer container: String,
         toFile destinationUrl: URL,
-        withRestorationId restorationId: String,
         withOptions options: DownloadBlobOptions? = nil
     ) throws -> Transfer? {
         // Construct URL
@@ -437,14 +468,12 @@ public final class StorageBlobClient: PipelineClient {
     ///   - container: The name of the container.
     ///   - blob: The name of the blob.
     ///   - properties: Properties to set on the resulting blob.
-    ///   - restorationId: An identifier that it is used to recreate the client and resume an operation.
     ///   - options: An `UploadBlobOptions` object to control the upload operation.
     public func upload(
         file sourceUrl: URL,
         toContainer container: String,
         asBlob blob: String,
         properties: BlobProperties,
-        withRestorationId restorationId: String,
         withOptions options: UploadBlobOptions? = nil
     ) throws -> Transfer? {
         // Construct URL

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -638,12 +638,16 @@ extension StorageBlobClient {
     /// - Parameters:
     ///   - transfer: The transfer to cancel.
     public func cancel(transfer: Transfer) {
+        guard let transfer = transfer as? TransferImpl else { return }
+        if transfer.clientRestorationId != restorationId {
+            assertionFailure("Canceling transfer not created by this StorageBlobClient")
+        }
         manager.cancel(transfer: transfer)
     }
 
-    /// Cancel all currently active transfers.
+    /// Cancel all currently active transfers having this client's `restorationId`.
     public func cancelAllTransfers() {
-        manager.cancelAll()
+        manager.cancelAll(withRestorationId: restorationId)
     }
 
     /// Remove a transfer from the database. If the transfer is currently active it will be cancelled.
@@ -651,12 +655,17 @@ extension StorageBlobClient {
     /// - Parameters:
     ///   - transfer: The transfer to remove.
     public func remove(transfer: Transfer) {
+        guard let transfer = transfer as? TransferImpl else { return }
+        if transfer.clientRestorationId != restorationId {
+            assertionFailure("Removing transfer not created by this StorageBlobClient")
+        }
         manager.remove(transfer: transfer)
     }
 
-    /// Remove all transfers from the database. All currently active transfers will be cancelled.
+    /// Remove all transfers having this client's `restorationId` from the database. All currently active transfers will
+    /// be cancelled.
     public func removeAllTransfers() {
-        manager.removeAll()
+        manager.removeAll(withRestorationId: restorationId)
     }
 
     /// Pause a currently active transfer.
@@ -664,12 +673,16 @@ extension StorageBlobClient {
     /// - Parameters:
     ///   - transfer: The transfer to pause.
     public func pause(transfer: Transfer) {
+        guard let transfer = transfer as? TransferImpl else { return }
+        if transfer.clientRestorationId != restorationId {
+            assertionFailure("Pausing transfer not created by this StorageBlobClient")
+        }
         manager.pause(transfer: transfer)
     }
 
-    /// Pause all currently active transfers.
+    /// Pause all currently active transfers having this client's `restorationId`.
     public func pauseAllTransfers() {
-        manager.pauseAll()
+        manager.pauseAll(withRestorationId: restorationId)
     }
 
     /// Resume a currently paused transfer.
@@ -677,16 +690,20 @@ extension StorageBlobClient {
     /// - Parameters:
     ///   - transfer: The transfer to resume.
     public func resume(transfer: Transfer) {
+        guard let transfer = transfer as? TransferImpl else { return }
+        if transfer.clientRestorationId != restorationId {
+            assertionFailure("Resuming transfer not created by this StorageBlobClient")
+        }
         manager.resume(transfer: transfer)
     }
 
-    /// Resume all currently paused transfers.
+    /// Resume all currently paused transfers having this client's `restorationId`.
     public func resumeAllTransfers() {
-        manager.resumeAll()
+        manager.resumeAll(withRestorationId: restorationId)
     }
 
-    /// Retrieve the list of all currently managed transfers.
+    /// Retrieve the list of all managed transfers having this client's `restorationId`.
     public var transfers: [Transfer] {
-        return manager.transfers
+        return manager.transfers.filter { $0.clientRestorationId == restorationId }
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -46,7 +46,6 @@ public final class StorageBlobClient: PipelineClient {
         "https://storage.azure.com/.default"
     ]
 
-    private var managing = false
     private let manager: TransferManager = URLSessionTransferManager.shared
     private let restorationId: String
 
@@ -611,11 +610,7 @@ extension StorageBlobClient {
     /// transfers" message and wait for explicit user confirmation to start the management engine). If you're not using
     /// such a credential, or there are no paused transfers, it is safe to call this method from your `AppDelegate`.
     public func startManaging() {
-        if managing { return }
-
-        manager.reachability?.startListening()
-
-        managing = true
+        manager.startManaging()
     }
 
     /// Stop the transfer management engine.
@@ -624,13 +619,7 @@ extension StorageBlobClient {
     /// disk. This method **SHOULD** be called by your application, either from your `AppDelegate` or from within a
     /// `ViewController`'s lifecycle methods.
     public func stopManaging() {
-        guard managing else { return }
-
-        manager.reachability?.stopListening()
-        pauseAllTransfers()
-        manager.saveContext()
-
-        managing = false
+        manager.stopManaging()
     }
 
     /// Cancel a currently active transfer.

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -32,21 +32,16 @@ import CoreData
 internal protocol TransferManager: ResumableOperationQueueDelegate {
     // MARK: Properties
 
-    var reachability: ReachabilityManager? { get }
     var persistentContainer: NSPersistentContainer? { get }
 
+    // MARK: Lifecycle Methods
+
     func register(client: StorageBlobClient?, forRestorationId: String)
-
-    // MARK: Storage Methods
-
-    // TODO: Uplevel the relelvant func signatures into TM protocol once reviewed
-    // func upload(_ url: URL) -> Transferable
-    // func download(_ url: URL) -> Transferable
-    // func copy(from source: URL, to destination: URL) -> Transferable
+    func startManaging()
+    func stopManaging()
 
     // MARK: Queue Operations
 
-    var count: Int { get }
     subscript(_: Int) -> TransferImpl { get }
     var transfers: [TransferImpl] { get }
 

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -47,18 +47,19 @@ internal protocol TransferManager: ResumableOperationQueueDelegate {
     // MARK: Queue Operations
 
     var count: Int { get }
-    subscript(_: Int) -> Transfer { get }
-    var transfers: [Transfer] { get }
+    subscript(_: Int) -> TransferImpl { get }
+    var transfers: [TransferImpl] { get }
 
-    func add(transfer: Transfer)
-    func cancel(transfer: Transfer)
-    func cancelAll()
-    func pause(transfer: Transfer)
-    func pauseAll()
-    func remove(transfer: Transfer)
-    func removeAll()
-    func resume(transfer: Transfer)
-    func resumeAll()
+    func add(transfer: TransferImpl)
+    func cancel(transfer: TransferImpl)
+    func cancelAll(withRestorationId: String?)
+    func pause(transfer: TransferImpl)
+    func pauseAll(withRestorationId: String?)
+    func remove(transfer: TransferImpl)
+    func removeAll(withRestorationId: String?)
+    func resume(transfer: TransferImpl)
+    func resumeAll(withRestorationId: String?)
+
     func loadContext()
     func saveContext()
 }

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -34,8 +34,8 @@ internal protocol TransferManager: ResumableOperationQueueDelegate {
 
     var reachability: ReachabilityManager? { get }
     var persistentContainer: NSPersistentContainer? { get }
-    var logger: ClientLogger { get set }
-    var delegate: TransferDelegate? { get set }
+
+    func register(client: StorageBlobClient?, forRestorationId: String)
 
     // MARK: Storage Methods
 

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+ResumableOperationQueueDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+ResumableOperationQueueDelegate.swift
@@ -30,6 +30,7 @@ extension URLSessionTransferManager: ResumableOperationQueueDelegate {
     internal func operation(_ operation: ResumableOperation?, didChangeState state: TransferState) {
         saveContext()
         guard let transfer = operation?.transfer else { return }
+        let delegate = client(forRestorationId: transfer.clientRestorationId)
         switch state {
         case .failed:
             // Block transfers should propagate up to their BlobTransfer and only notify that the

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -445,7 +445,13 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
 
         // attempt to attach one
         guard let client = client(forRestorationId: transfer.clientRestorationId) else {
-            transfer.error = AzureError.general("Unable to restore client.")
+            let errorMessage = """
+            Attempted to resume this transfer, but no client with restorationId "\(transfer.clientRestorationId)" has \
+            been initialized.
+            """
+            assertionFailure(errorMessage)
+
+            transfer.error = AzureError.general(errorMessage)
             transfer.state = .failed
             return
         }


### PR DESCRIPTION
This way, a customer only has to provide the restoration ID when
initializing a client. The client is later looked up from the registry
if it's found to be missing from the transfer. If no client exists in
the registry when the transfer is resumed, it will be marked as failed.