### PR TITLE
Set max concurrency of StorageBlobClient.

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -99,7 +99,8 @@ struct AppState {
             )
             let options = StorageBlobClientOptions(
                 apiVersion: StorageBlobClient.ApiVersion.latest.rawValue,
-                logger: ClientLoggers.none
+                logger: ClientLoggers.none,
+                maxConcurrency: 2
             )
             client = StorageBlobClient(
                 accountUrl: AppConstants.storageAccountUrl,

--- a/sdk/storage/AzureStorageBlob/Source/DataStructures/StorageBlobClientOptions.swift
+++ b/sdk/storage/AzureStorageBlob/Source/DataStructures/StorageBlobClientOptions.swift
@@ -39,6 +39,9 @@ public struct StorageBlobClientOptions: AzureConfigurable {
     /// The maximum size of a single chunk in a blob upload or download.
     public let maxChunkSize: Int
 
+    /// The maximum number of threads to use for uploading and downloading. Omit to let the OS decide.
+    public let maxConcurrency: Int?
+
     /// Initialize a `StorageBlobClientOptions` structure.
     /// - Parameters:
     ///   - apiVersion: The API version of the Azure Storage Blob service to invoke.
@@ -47,11 +50,13 @@ public struct StorageBlobClientOptions: AzureConfigurable {
     public init(
         apiVersion: String = StorageBlobClient.ApiVersion.latest.rawValue,
         logger: ClientLogger = ClientLoggers.default(tag: "StorageBlobClient"),
-        maxChunkSize: Int = 4 * 1024 * 1024
+        maxChunkSize: Int = 4 * 1024 * 1024,
+        maxConcurrency: Int? = nil
     ) {
         self.apiVersion = apiVersion
         self.logger = logger
         self.maxChunkSize = maxChunkSize
+        self.maxConcurrency = maxConcurrency
     }
 }
 
@@ -199,9 +204,6 @@ public struct DownloadBlobOptions: AzureOptions, Codable, Equatable {
     /// a secure connection must be established to transfer the key.
     public let customerProvidedEncryptionKey: CustomerProvidedEncryptionKey?
 
-    /// The number of parallel connections with which to download.
-    public let maxConcurrency: Int?
-
     /// Encoding with which to decode the downloaded bytes. If nil, no decoding occurs.
     public let encoding: String?
 
@@ -229,7 +231,6 @@ public struct DownloadBlobOptions: AzureOptions, Codable, Equatable {
     ///   - customerProvidedEncryptionKey: Encrypts the data on the service-side with the given key. Use of
     ///     customer-provided keys must be done over HTTPS. As the encryption key itself is provided in the request, a
     ///     secure connection must be established to transfer the key.
-    ///   - maxConcurrency: The number of parallel connections with which to download.
     ///   - encoding: Encoding with which to decode the downloaded bytes. If nil, no decoding occurs.
     ///   - timeout: The timeout parameter is expressed in seconds. This method may make multiple calls to the Azure
     ///     service and the timeout will apply to each call individually.
@@ -242,7 +243,6 @@ public struct DownloadBlobOptions: AzureOptions, Codable, Equatable {
         modifiedAccessConditions: ModifiedAccessConditions? = nil,
         encryptionOptions: EncryptionOptions? = nil,
         customerProvidedEncryptionKey: CustomerProvidedEncryptionKey? = nil,
-        maxConcurrency: Int? = nil,
         encoding: String? = nil,
         timeout: Int? = nil
     ) {
@@ -254,7 +254,6 @@ public struct DownloadBlobOptions: AzureOptions, Codable, Equatable {
         self.modifiedAccessConditions = modifiedAccessConditions
         self.encryptionOptions = encryptionOptions
         self.customerProvidedEncryptionKey = customerProvidedEncryptionKey
-        self.maxConcurrency = maxConcurrency
         self.encoding = encoding
         self.timeout = timeout
     }
@@ -288,9 +287,6 @@ public struct UploadBlobOptions: AzureOptions, Codable, Equatable {
     /// this value implies use of the default account encryption scope.
     public let customerProvidedEncryptionScope: String?
 
-    /// The number of parallel connections with which to upload.
-    public let maxConcurrency: Int?
-
     /// Encoding with which to encode the uploaded bytes. If nil, no encoding occurs.
     public let encoding: String?
 
@@ -315,7 +311,6 @@ public struct UploadBlobOptions: AzureOptions, Codable, Equatable {
     ///     secure connection must be established to transfer the key.
     ///   - customerProvidedEncryptionScope: The name of the predefined encryption scope used to encrypt the blob
     ///   contents and metadata. Note that omitting this value implies use of the default account encryption scope.
-    ///   - maxConcurrency: The number of parallel connections with which to upload.
     ///   - encoding: Encoding with which to decode the downloaded bytes. If nil, no decoding occurs.
     ///   - timeout: The timeout parameter is expressed in seconds. This method may make multiple calls to the Azure
     ///     service and the timeout will apply to each call individually.
@@ -326,7 +321,6 @@ public struct UploadBlobOptions: AzureOptions, Codable, Equatable {
         encryptionOptions: EncryptionOptions? = nil,
         customerProvidedEncryptionKey: CustomerProvidedEncryptionKey? = nil,
         customerProvidedEncryptionScope: String? = nil,
-        maxConcurrency: Int? = nil,
         encoding: String? = nil,
         timeout: Int? = nil
     ) {
@@ -336,7 +330,6 @@ public struct UploadBlobOptions: AzureOptions, Codable, Equatable {
         self.encryptionOptions = encryptionOptions
         self.customerProvidedEncryptionKey = customerProvidedEncryptionKey
         self.customerProvidedEncryptionScope = customerProvidedEncryptionScope
-        self.maxConcurrency = maxConcurrency
         self.encoding = encoding
         self.timeout = timeout
     }

--- a/sdk/storage/AzureStorageBlob/Source/Operation/ResumableOperationQueue.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/ResumableOperationQueue.swift
@@ -50,16 +50,6 @@ internal class ResumableOperationQueue {
         }
     }
 
-    public var maxConcurrentOperationCount: Int {
-        get {
-            return operationQueue.maxConcurrentOperationCount
-        }
-
-        set {
-            operationQueue.maxConcurrentOperationCount = newValue
-        }
-    }
-
     public var count: Int {
         return operations.count
     }

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -87,6 +87,9 @@ public final class StorageBlobClient: PipelineClient {
             logger: self.options.logger
         )
         manager.register(client: self, forRestorationId: restorationId)
+        if let maxConcurrency = options?.maxConcurrency {
+            manager.maxConcurrentOperationCount = maxConcurrency
+        }
     }
 
     /// Create a Storage blob data client.

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -43,6 +43,7 @@ internal protocol TransferManager: ResumableOperationQueueDelegate {
     // MARK: Queue Operations
 
     subscript(_: Int) -> TransferImpl { get }
+    var maxConcurrentOperationCount: Int { get set }
     var transfers: [TransferImpl] { get }
 
     func add(transfer: TransferImpl)

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -34,6 +34,16 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
 
     // MARK: Properties
 
+    public var maxConcurrentOperationCount: Int {
+        get {
+            return operationQueue.operationQueue.maxConcurrentOperationCount
+        }
+
+        set {
+            operationQueue.operationQueue.maxConcurrentOperationCount = newValue
+        }
+    }
+
     var clients = NSMapTable<NSString, StorageBlobClient>.strongToWeakObjects()
 
     lazy var session: URLSession = {
@@ -88,7 +98,6 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
 
         super.init()
         operationQueue.delegate = self
-        operationQueue.maxConcurrentOperationCount = 4
     }
 
     // TODO: This will interfere with trying to use multiple BlobClients simultaneously. Find an alternate


### PR DESCRIPTION
Allows setting client max concurrency through StorageBlobClientOptions. If not provided, will let the OS use the default value. Closes #253.