### PR TITLE
UX Study Fixes.

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -138,7 +138,8 @@ extension UIViewController {
             if let pipelineError = error as? PipelineError {
                 errorString = pipelineError.innerError.localizedDescription
             } else {
-                errorString = error.localizedDescription
+                let errorInfo = (error as NSError).userInfo
+                errorString = errorInfo[NSDebugDescriptionErrorKey] as? String ?? error.localizedDescription
             }
             self?.hideActivitySpinner()
             let alertController = UIAlertController(title: "Error!", message: errorString, preferredStyle: .alert)

--- a/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
@@ -74,6 +74,7 @@ internal protocol TransferImpl: Transfer {
     var operation: ResumableOperation? { get set }
     var state: TransferState { get set }
     var rawState: Int16 { get set }
+    var isActive: Bool { get }
 }
 
 // MARK: Extensions
@@ -99,6 +100,10 @@ public extension Transfer {
     func resume() {
         guard let transfer = self as? TransferImpl else { return }
         URLSessionTransferManager.shared.resume(transfer: transfer)
+    }
+
+    var isActive: Bool {
+        return state.active
     }
 }
 

--- a/sdk/storage/AzureStorageBlob/Source/DataStructures/Enumerations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/DataStructures/Enumerations.swift
@@ -29,9 +29,9 @@ import Foundation
 /// The access tier of a blob.
 public enum AccessTier: String, Codable {
     /// Hot access tier.
-    case hot
-    /// Cold access tier.
-    case cold
+    case hot = "Hot"
+    /// Cool access tier.
+    case cool = "Cool"
 }
 
 /// The type of a blob.

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlobUploadOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlobUploadOperations.swift
@@ -31,8 +31,7 @@ internal class BlobUploadFinalOperation: ResumableOperation {
     // MARK: Initializers
 
     public convenience init(withTransfer transfer: BlobTransfer, queue: ResumableOperationQueue) {
-        self.init(state: transfer.state)
-        self.transfer = transfer
+        self.init(transfer: transfer, state: transfer.state)
         self.queue = queue
         transfer.operation = self
     }

--- a/sdk/storage/AzureStorageBlob/Source/Operation/MultiBlobOperation.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/MultiBlobOperation.swift
@@ -35,6 +35,7 @@ internal class MultiBlobOperation: ResumableOperation {
     // MARK: Initializers
 
     public init(withTransfer transfer: MultiBlobTransfer) {
+        super.init(transfer: transfer)
         self.parent = transfer
     }
 
@@ -46,13 +47,5 @@ internal class MultiBlobOperation: ResumableOperation {
         transfer.state = .complete
         delegate?.operation(self, didChangeState: transfer.state)
         super.main()
-    }
-
-    public override func cancel() {
-        super.cancel()
-    }
-
-    public override func pause() {
-        super.pause()
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/Operation/ResumableOperation.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/ResumableOperation.swift
@@ -39,7 +39,7 @@ internal class ResumableOperation: Operation {
         return internalState
     }
 
-    public weak var transfer: TransferImpl?
+    public var transfer: TransferImpl
     public weak var delegate: ResumableOperationDelegate?
     public weak var queue: ResumableOperationQueue?
 
@@ -53,8 +53,9 @@ internal class ResumableOperation: Operation {
 
     // MARK: Initializers
 
-    public init(state: TransferState = .pending, delegate: ResumableOperationDelegate? = nil) {
+    public init(transfer: TransferImpl, state: TransferState = .pending, delegate: ResumableOperationDelegate? = nil) {
         self.internalState = state
+        self.transfer = transfer
         self.delegate = delegate
     }
 
@@ -63,6 +64,7 @@ internal class ResumableOperation: Operation {
     open override func main() {
         if isCancelled || isPaused { return }
         internalState = .complete
+        super.main()
     }
 
     open override func start() {
@@ -106,8 +108,8 @@ internal class ResumableOperation: Operation {
         // Notify the delegate of the block change AND the parent change.
         // This allows the developer to decide which events to respond to.
         delegate?.operation(self, didChangeState: transfer.state)
-        if let parent = transfer.parent.operation, let parentState = parent.transfer?.state {
-            delegate?.operation(parent, didChangeState: parentState)
+        if let parent = transfer.parent.operation {
+            delegate?.operation(parent, didChangeState: parent.transfer.state)
         }
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -261,7 +261,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
         transfer.state = .canceled
         assert(transfer.operation != nil, "Transfer operation unexpectedly nil.")
         if let operation = transfer.operation {
-            operationQueue.remove(operation)
+            operationQueue.cancel(operation)
         }
         if let blob = transfer as? BlobTransfer {
             for block in blob.transfers {
@@ -327,7 +327,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
 
     func remove(transfer: BlockTransfer) {
         if let operation = transfer.operation {
-            operationQueue.remove(operation)
+            operationQueue.cancel(operation)
         }
 
         if let index = transfers.firstIndex(where: { $0 === transfer }) {
@@ -343,11 +343,11 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
     internal func remove(transfer: BlobTransfer) {
         // Cancel the operation and any associated block operations
         if let operation = transfer.operation {
-            operationQueue.remove(operation)
+            operationQueue.cancel(operation)
             for block in transfer.transfers {
                 block.state = .deleted
                 if let blockOp = block.operation {
-                    operationQueue.remove(blockOp)
+                    operationQueue.cancel(blockOp)
                 }
             }
         }
@@ -389,7 +389,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
 
         // Cancel the operation
         if let operation = transfer.operation {
-            operationQueue.remove(operation)
+            operationQueue.cancel(operation)
         }
 
         // Pause any pauseable blocks and cancel their operations
@@ -407,7 +407,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
 
         // Cancel the operation
         if let operation = transfer.operation {
-            operationQueue.remove(operation)
+            operationQueue.cancel(operation)
         }
 
         // notify delegate


### PR DESCRIPTION
- Fixes #261. 
- Improves the `showAlert(error:)` method to print the debugDescription, if available (fixes #266).
- Fixes an issue with the `AccessTier` enum that prevented it from being properly deserialized.

There were some holes in the Operation logic. I took the opportunity to simplify ResumableOperation and ResumableOperationQueue. I would like to further shrink these, but right now, it isn't necessary.

I believe the key problem was in the BlockOperation logic. After entering a dispatch group, there were return statements that did not have a matching `group.leave()` call. As a result, these threads were lost to the ether and never able to complete. So, when the the operation was resumed, all incomplete blocks were readded to the queue but could never proceed because the original threads were lost and could never complete their lifecycle.