### PR TITLE
Fix MD5 hashing and restore to true

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -78,9 +78,8 @@ struct AppState {
     }
 
     static var downloadOptions: DownloadBlobOptions {
-        // TODO: Diagnose issues with EXC_BAD_ACCESS and restore to true
         let options = DownloadBlobOptions(
-            range: RangeOptions(calculateMD5: false)
+            range: RangeOptions(calculateMD5: true)
         )
         return options
     }

--- a/sdk/storage/AzureStorageBlob/Source/DataStructures/StorageBlobClientOptions.swift
+++ b/sdk/storage/AzureStorageBlob/Source/DataStructures/StorageBlobClientOptions.swift
@@ -47,7 +47,7 @@ public struct StorageBlobClientOptions: AzureConfigurable {
     public init(
         apiVersion: String = StorageBlobClient.ApiVersion.latest.rawValue,
         logger: ClientLogger = ClientLoggers.default(tag: "StorageBlobClient"),
-        maxChunkSize: Int = 4 * 1024 * 1024
+        maxChunkSize: Int = 4 * 1024 * 1024 - 1
     ) {
         self.apiVersion = apiVersion
         self.logger = logger

--- a/sdk/storage/AzureStorageBlob/Source/DataStructures/StorageBlobClientOptions.swift
+++ b/sdk/storage/AzureStorageBlob/Source/DataStructures/StorageBlobClientOptions.swift
@@ -44,6 +44,7 @@ public struct StorageBlobClientOptions: AzureConfigurable {
     ///   - apiVersion: The API version of the Azure Storage Blob service to invoke.
     ///   - logger: The `ClientLogger` to be used by this `StorageBlobClient`.
     ///   - maxChunkSize: The maximum size of a single chunk in a blob upload or download.
+    ///     Must be less than 4MB if enabling MD5 or CRC64 hashing.
     public init(
         apiVersion: String = StorageBlobClient.ApiVersion.latest.rawValue,
         logger: ClientLogger = ClientLoggers.default(tag: "StorageBlobClient"),

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -160,9 +160,7 @@ internal class ChunkDownloader {
         let modifiedAccessConditions = options.modifiedAccessConditions
         let cpk = options.customerProvidedEncryptionKey
 
-        let rangeString = "bytes=\(startRange)-\(endRange)"
-        headers[.range] = rangeString
-        headers[.xmsRange] = rangeString
+        headers[.range] = "bytes=\(startRange)-\(endRange)"
         if let rangeGetContentMD5 = options.range?.calculateMD5 {
             headers[.rangeGetContentMD5] = String(rangeGetContentMD5)
         }

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -160,12 +160,16 @@ internal class ChunkDownloader {
         let modifiedAccessConditions = options.modifiedAccessConditions
         let cpk = options.customerProvidedEncryptionKey
 
-        headers[.xmsRange] = "bytes=\(startRange)-\(endRange)"
         if let rangeGetContentMD5 = options.range?.calculateMD5 {
             headers[.rangeGetContentMD5] = String(rangeGetContentMD5)
+            headers[.range] = "bytes=\(startRange)-\(endRange)"
         }
         if let rangeGetContentCRC64 = options.range?.calculateCRC64 {
             headers[.rangeGetContentCRC64] = String(rangeGetContentCRC64)
+            headers[.range] = "bytes=\(startRange)-\(endRange)"
+        }
+        if headers[.range] == nil {
+            headers[.xmsRange] = "bytes=\(startRange)-\(endRange)"
         }
 
         if let requestId = requestId { headers[.clientRequestId] = requestId }

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -160,16 +160,14 @@ internal class ChunkDownloader {
         let modifiedAccessConditions = options.modifiedAccessConditions
         let cpk = options.customerProvidedEncryptionKey
 
+        let rangeString = "bytes=\(startRange)-\(endRange)"
+        headers[.range] = rangeString
+        headers[.xmsRange] = rangeString
         if let rangeGetContentMD5 = options.range?.calculateMD5 {
             headers[.rangeGetContentMD5] = String(rangeGetContentMD5)
-            headers[.range] = "bytes=\(startRange)-\(endRange)"
         }
         if let rangeGetContentCRC64 = options.range?.calculateCRC64 {
             headers[.rangeGetContentCRC64] = String(rangeGetContentCRC64)
-            headers[.range] = "bytes=\(startRange)-\(endRange)"
-        }
-        if headers[.range] == nil {
-            headers[.xmsRange] = "bytes=\(startRange)-\(endRange)"
         }
 
         if let requestId = requestId { headers[.clientRequestId] = requestId }


### PR DESCRIPTION
Fixes #248.  I think the actual `EXC_BAD_ACCESS` was fixed by an earlier PR. This simply tweaks previously merged changes that caused turning the option on to yield a 400 error.