### PR TITLE
Fix progress bar regressions

### DIFF
--- a/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
@@ -44,9 +44,7 @@ public struct TransferProgress {
     public var asFloat: Float {
         // Returning NaN sometimes results in progress appearing as 100% when it shouldn't.
         // This ensures progress will report 0%.
-        assert(bytes <= totalBytes, "Transferred bytes unexpectedly > than total bytes.")
         if totalBytes <= 0 { return 0 }
-        if bytes == totalBytes { return 1.0 }
         return Float(bytes) / Float(totalBytes)
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
@@ -44,7 +44,10 @@ public struct TransferProgress {
     public var asFloat: Float {
         // Returning NaN sometimes results in progress appearing as 100% when it shouldn't.
         // This ensures progress will report 0%.
+        // TODO: Debug concurrency instabilitites triggering this
+        // assert(bytes <= totalBytes, "Transferred bytes unexpectedly > than total bytes.")
         if totalBytes <= 0 { return 0 }
+        if bytes == totalBytes { return 1.0 }
         return Float(bytes) / Float(totalBytes)
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlobDownloadOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlobDownloadOperations.swift
@@ -96,10 +96,16 @@ internal class BlobDownloadInitialOperation: TransferOperation {
 
         let group = DispatchGroup()
         group.enter()
-        downloader.initialRequest { result, _ in
+        downloader.initialRequest { result, httpResponse in
             switch result {
             case .success:
+                guard let responseHeaders = httpResponse?.headers else {
+                    assertionFailure("Response headers not found.")
+                    return
+                }
+                let blobProperties = BlobProperties(from: responseHeaders)
                 parent.totalBytesToTransfer = Int64(downloader.totalSize)
+                parent.bytesTransferred += Int64(blobProperties.contentLength ?? 0)
                 transfer.state = .complete
                 self.queueRemainingBlocks(forTransfer: parent)
                 self.notifyDelegate(withTransfer: parent)

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlockOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlockOperations.swift
@@ -77,7 +77,7 @@ internal class BlockOperation: TransferOperation {
                         return
                     }
                     let blobProperties = BlobProperties(from: responseHeaders)
-                    let bytesTransferred = blobProperties.contentLength ?? 0
+                    let bytesTransferred = (blobProperties.contentLength ?? 1) - 1
                     downloader.progress += bytesTransferred
                     parent.bytesTransferred += Int64(bytesTransferred)
                     transfer.state = .complete

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -430,7 +430,7 @@ internal class BlobStreamDownloader: BlobDownloader {
                     // extract the file size from the content range. If a specific size request was
                     // not made, then the request is for the entire file.
                     let blobSize = try self.parseLength(fromContentRange: contentRange)
-                    self.totalSize = blobSize
+                    self.totalSize = blobSize - 1
                     self.progress += blobProperties.contentLength ?? 0
                     self.blobProperties = blobProperties
 

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -496,6 +496,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
                     properties: blobProperties,
                     options: uploadOptions
                 )
+                transfer.uploader?.progress = Int(transfer.bytesTransferred)
             case .download:
                 guard let sourceUrl = transfer.source else { return }
                 guard let destUrl = transfer.destination else { return }
@@ -507,6 +508,8 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
                     destination: destination,
                     options: transfer.downloadOptions
                 )
+                transfer.downloader?.progress = Int(transfer.bytesTransferred)
+                transfer.downloader?.totalSize = Int(transfer.totalBytesToTransfer)
             }
         } catch {
             client.logger.error(error.localizedDescription)


### PR DESCRIPTION
Fixes issues introduced by #272:
- Completed downloads only showing a progress bar to 90-ish % complete due to the initial block not being counted. 
- off-by-one errors in calculating total bytes
- issue where reconnected uploaders/downloaders would have incorrect progress information


