### PR TITLE
Fix BlobTransfer local URLs are unresolved

### DIFF
--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataClass.swift
@@ -84,6 +84,20 @@ public class BlobTransfer: NSManagedObject, Transfer {
         }
     }
 
+    /// The source of the transfer. For uploads, this is the absolute local path on the device of the file being
+    /// uploaded. For downloads, this is the URL of the blob being downloaded.
+    public var sourceUrl: URL? {
+        guard let url = source else { return nil }
+        return transferType == .upload ? LocalURL(fromAbsoluteUrl: url).resolvedUrl : url
+    }
+
+    /// The destination of the transfer. For uploads, this is the blob URL where the file is being uploaded. For
+    /// downloads, this is the absolute local path on the device to which the blob is being downloaded.
+    public var destinationUrl: URL? {
+        guard let url = destination else { return nil }
+        return transferType == .download ? LocalURL(fromAbsoluteUrl: url).resolvedUrl : url
+    }
+
     // FIXME: The fact that BlobProperties, DownloadBlobOptions, and UploadBlobOptions are structs causes serious
     // problems here. It will always return nil if allowed to be optional.
     private var cachedProperties: BlobProperties?

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
@@ -38,9 +38,7 @@ extension BlobTransfer {
     /// been initialized. Attempting to resume it without previously initializing such a client will cause the transfer
     /// to transition to the `failed` state.
     @NSManaged public internal(set) var clientRestorationId: String
-    /// The destination of the transfer. For uploads, this is the blob URL where the file is being uploaded. For
-    /// downloads, this is the local path on the device to which the blob is being downloaded.
-    @NSManaged public internal(set) var destination: URL?
+    @NSManaged internal var destination: URL?
     @NSManaged internal var endRange: Int64
     /// The error that was encountered during the transfer, if any.
     @NSManaged public internal(set) var error: Error?
@@ -50,9 +48,7 @@ extension BlobTransfer {
     /// :nodoc: Internal representation of the state.
     @NSManaged public internal(set) var rawState: Int16
     @NSManaged internal var rawType: Int16
-    /// The source of the transfer. For uploads, this is the local path on the device of the file being uploaded. For
-    /// downloads, this is the URL of the blob being downloaded.
-    @NSManaged public internal(set) var source: URL?
+    @NSManaged internal var source: URL?
     @NSManaged internal var startRange: Int64
     @NSManaged internal var totalBlocks: Int64
     @NSManaged internal var blocks: NSSet?


### PR DESCRIPTION
Fixes #281 

The source and destination URLs on a blob transfer are the raw values
    that get stored in CoreData. They aren't appropriate for a user to
    consume directly, so those have been hidden and instead we add the
    sourceUrl and destinationUrl properties that correctly resolve the value
    if it represents a LocalURL.