### PR TITLE
Perform callbacks on DispatchQueue.main

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/AppDelegate.swift
+++ b/examples/AzureSDKDemoSwift/Source/AppDelegate.swift
@@ -88,7 +88,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also
         // applicationDidEnterBackground:.
-        try? StorageBlobClient.stopManaging()
+        StorageBlobClient.stopManaging()
     }
 
     func application(

--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -73,11 +73,11 @@ class BlobDownloadViewController: UIViewController, MSALInteractiveDelegate {
             tableView.refreshControl?.beginRefreshing()
         }
         blobClient.listBlobs(inContainer: containerName, withOptions: options) { result, _ in
-            DispatchQueue.main.async { self.tableView.refreshControl?.endRefreshing() }
+            self.tableView.refreshControl?.endRefreshing()
             switch result {
             case let .success(paged):
                 self.dataSource = paged
-                self.reloadTableView()
+                self.tableView.reloadData()
             case let .failure(error):
                 self.showAlert(error: error)
                 self.noMoreData = true
@@ -92,7 +92,7 @@ class BlobDownloadViewController: UIViewController, MSALInteractiveDelegate {
             switch result {
             case let .success(data):
                 if data != nil {
-                    self.reloadTableView()
+                    self.tableView.reloadData()
                 } else {
                     self.noMoreData = true
                 }
@@ -100,13 +100,6 @@ class BlobDownloadViewController: UIViewController, MSALInteractiveDelegate {
                 self.showAlert(error: error)
                 self.noMoreData = true
             }
-        }
-    }
-
-    /// Reload the table view on the UI thread.
-    private func reloadTableView() {
-        DispatchQueue.main.async { [weak self] in
-            self?.tableView.reloadData()
         }
     }
 
@@ -218,9 +211,7 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
         } catch {
             showAlert(error: error)
         }
-        DispatchQueue.main.async { [weak self] in
-            self?.tableView.deselectRow(at: indexPath, animated: true)
-        }
+        self.tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 
@@ -235,22 +226,22 @@ extension BlobDownloadViewController: TransferDelegate {
         andProgress progress: Float?
     ) {
         if let blobTransfer = transfer as? BlobTransfer, blobTransfer.transferType == .download {
-            reloadTableView()
+            tableView.reloadData()
         }
     }
 
     func transfersDidUpdate(_: [Transfer]) {
-        reloadTableView()
+        tableView.reloadData()
     }
 
     func transferDidComplete(_ transfer: Transfer) {
         if let blobTransfer = transfer as? BlobTransfer, blobTransfer.transferType == .download {
-            reloadTableView()
+            tableView.reloadData()
         }
     }
 
     func transfer(_: Transfer, didFailWithError error: Error) {
         showAlert(error: error)
-        reloadTableView()
+        tableView.reloadData()
     }
 }

--- a/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
@@ -141,16 +141,7 @@ class BlobUploadViewController: UIViewController, MSALInteractiveDelegate {
         group.notify(queue: .main) {
             PHPhotoLibrary.authorizationStatus()
             StorageBlobClient.startManaging()
-            self.reloadCollectionView()
-        }
-    }
-
-    // MARK: Private Methods
-
-    /// Reload the table view on the UI thread.
-    private func reloadCollectionView() {
-        DispatchQueue.main.async { [weak self] in
-            self?.collectionView.reloadData()
+            self.collectionView.reloadData()
         }
     }
 
@@ -204,9 +195,7 @@ extension BlobUploadViewController: UICollectionViewDelegate, UICollectionViewDa
 
     func collectionView(_: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         defer {
-            DispatchQueue.main.async { [weak self] in
-                self?.collectionView.deselectItem(at: indexPath, animated: true)
-            }
+            self.collectionView.deselectItem(at: indexPath, animated: true)
         }
         guard let containerName = AppConstants.uploadContainer else { return }
         guard let blobClient = blobClient else { return }
@@ -275,22 +264,22 @@ extension BlobUploadViewController: TransferDelegate {
         andProgress progress: Float?
     ) {
         if let blobTransfer = transfer as? BlobTransfer, blobTransfer.transferType == .upload {
-            reloadCollectionView()
+            collectionView.reloadData()
         }
     }
 
     func transfersDidUpdate(_: [Transfer]) {
-        reloadCollectionView()
+        collectionView.reloadData()
     }
 
     func transferDidComplete(_ transfer: Transfer) {
         if let blobTransfer = transfer as? BlobTransfer, blobTransfer.transferType == .upload {
-            reloadCollectionView()
+            collectionView.reloadData()
         }
     }
 
     func transfer(_: Transfer, didFailWithError error: Error) {
         showAlert(error: error)
-        reloadCollectionView()
+        collectionView.reloadData()
     }
 }

--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -132,34 +132,30 @@ class ActivtyViewController: UIViewController {
 
 extension UIViewController {
     internal func showAlert(error: Error) {
-        DispatchQueue.main.async { [weak self] in
-            guard self?.presentedViewController == nil else { return }
-            var errorString: String
-            if let pipelineError = error as? PipelineError {
-                errorString = pipelineError.innerError.localizedDescription
-            } else {
-                let errorInfo = (error as NSError).userInfo
-                errorString = errorInfo[NSDebugDescriptionErrorKey] as? String ?? error.localizedDescription
-            }
-            let alertController = UIAlertController(title: "Error!", message: errorString, preferredStyle: .alert)
-            let title = NSAttributedString(string: "Error!", attributes: [
-                NSAttributedString.Key.foregroundColor: UIColor.red
-            ])
-            alertController.setValue(title, forKey: "attributedTitle")
-            let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
-            alertController.addAction(defaultAction)
-            self?.present(alertController, animated: true)
+        guard presentedViewController == nil else { return }
+        var errorString: String
+        if let pipelineError = error as? PipelineError {
+            errorString = pipelineError.innerError.localizedDescription
+        } else {
+            let errorInfo = (error as NSError).userInfo
+            errorString = errorInfo[NSDebugDescriptionErrorKey] as? String ?? error.localizedDescription
         }
+        let alertController = UIAlertController(title: "Error!", message: errorString, preferredStyle: .alert)
+        let title = NSAttributedString(string: "Error!", attributes: [
+            NSAttributedString.Key.foregroundColor: UIColor.red
+        ])
+        alertController.setValue(title, forKey: "attributedTitle")
+        let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alertController.addAction(defaultAction)
+        present(alertController, animated: true)
     }
 
     internal func showAlert(message: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard self?.presentedViewController == nil else { return }
-            let alertController = UIAlertController(title: "Blob Contents", message: message, preferredStyle: .alert)
-            let defaultAction = UIAlertAction(title: "Close", style: .default, handler: nil)
-            alertController.addAction(defaultAction)
-            self?.present(alertController, animated: true)
-        }
+        guard presentedViewController == nil else { return }
+        let alertController = UIAlertController(title: "Blob Contents", message: message, preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: "Close", style: .default, handler: nil)
+        alertController.addAction(defaultAction)
+        present(alertController, animated: true)
     }
 }
 

--- a/examples/AzureSDKDemoSwift/Source/CustomCells.swift
+++ b/examples/AzureSDKDemoSwift/Source/CustomCells.swift
@@ -39,9 +39,7 @@ class CustomTableViewCell: UITableViewCell {
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
-        DispatchQueue.main.async {
-            super.setSelected(selected, animated: animated)
-        }
+        super.setSelected(selected, animated: animated)
     }
 }
 

--- a/examples/AzureSDKDemoSwift/Source/CustomTabBarController.swift
+++ b/examples/AzureSDKDemoSwift/Source/CustomTabBarController.swift
@@ -30,10 +30,6 @@ import UIKit
 class CustomTabBarController: UITabBarController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        do {
-            try StorageBlobClient.stopManaging()
-        } catch {
-            showAlert(error: error)
-        }
+        StorageBlobClient.stopManaging()
     }
 }

--- a/examples/AzureSDKDemoSwift/Source/LoginViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/LoginViewController.swift
@@ -73,14 +73,10 @@ class LoginViewController: UIViewController {
     }
 
     internal func updateLogOutButton(enabled: Bool) {
-        if Thread.isMainThread {
-            logOutButton.isEnabled = enabled
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.logOutButton.isEnabled = enabled
-            }
+        DispatchQueue.main.async { [weak self] in
+            self?.logOutButton.isEnabled = enabled
+            self?.updateUserLabel()
         }
-        updateUserLabel()
     }
 
     internal func updateUserLabel() {

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -620,22 +620,22 @@ extension StorageBlobClient: TransferDelegate {
         didUpdateWithState state: TransferState,
         andProgress progress: Float?
     ) {
-        delegate.transfer(transfer, didUpdateWithState: state, andProgress: progress)
+        transferDelegate?.transfer(transfer, didUpdateWithState: state, andProgress: progress)
     }
 
     /// :nodoc:
     public func transfersDidUpdate(_ transfers: [Transfer]) {
-        delegate.transfersDidUpdate(transfers)
+        transferDelegate?.transfersDidUpdate(transfers)
     }
 
     /// :nodoc:
     public func transfer(_ transfer: Transfer, didFailWithError error: Error) {
-        delegate.transfer(transfer, didFailWithError: error)
+        transferDelegate?.transfer(transfer, didFailWithError: error)
     }
 
     /// :nodoc:
     public func transferDidComplete(_ transfer: Transfer) {
-        delegate.transferDidComplete(transfer)
+        transferDelegate?.transferDidComplete(transfer)
     }
 }
 

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -620,34 +620,22 @@ extension StorageBlobClient: TransferDelegate {
         didUpdateWithState state: TransferState,
         andProgress progress: Float?
     ) {
-        guard let delegate = transferDelegate else { return }
-        DispatchQueue.main.async {
-            delegate.transfer(transfer, didUpdateWithState: state, andProgress: progress)
-        }
+        delegate.transfer(transfer, didUpdateWithState: state, andProgress: progress)
     }
 
     /// :nodoc:
     public func transfersDidUpdate(_ transfers: [Transfer]) {
-        guard let delegate = transferDelegate else { return }
-        DispatchQueue.main.async {
-            delegate.transfersDidUpdate(transfers)
-        }
+        delegate.transfersDidUpdate(transfers)
     }
 
     /// :nodoc:
     public func transfer(_ transfer: Transfer, didFailWithError error: Error) {
-        guard let delegate = transferDelegate else { return }
-        DispatchQueue.main.async {
-            delegate.transfer(transfer, didFailWithError: error)
-        }
+        delegate.transfer(transfer, didFailWithError: error)
     }
 
     /// :nodoc:
     public func transferDidComplete(_ transfer: Transfer) {
-        guard let delegate = transferDelegate else { return }
-        DispatchQueue.main.async {
-            delegate.transferDidComplete(transfer)
-        }
+        delegate.transferDidComplete(transfer)
     }
 }
 

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -274,7 +274,9 @@ public final class StorageBlobClient: PipelineClient {
             case let .success(data):
                 guard let data = data else {
                     let noDataError = HTTPResponseError.decode("Response data expected but not found.")
-                    completion(.failure(noDataError), httpResponse)
+                    DispatchQueue.main.async {
+                        completion(.failure(noDataError), httpResponse)
+                    }
                     return
                 }
                 do {
@@ -287,12 +289,18 @@ public final class StorageBlobClient: PipelineClient {
                         decoder: decoder,
                         delegate: self
                     )
-                    completion(.success(paged), httpResponse)
+                    DispatchQueue.main.async {
+                        completion(.success(paged), httpResponse)
+                    }
                 } catch {
-                    completion(.failure(error), httpResponse)
+                    DispatchQueue.main.async {
+                        completion(.failure(error), httpResponse)
+                    }
                 }
             case let .failure(error):
-                completion(.failure(error), httpResponse)
+                DispatchQueue.main.async {
+                    completion(.failure(error), httpResponse)
+                }
             }
         }
     }
@@ -361,7 +369,10 @@ public final class StorageBlobClient: PipelineClient {
             case let .success(data):
                 guard let data = data else {
                     let noDataError = HTTPResponseError.decode("Response data expected but not found.")
-                    completion(.failure(noDataError), httpResponse)
+
+                    DispatchQueue.main.async {
+                        completion(.failure(noDataError), httpResponse)
+                    }
                     return
                 }
                 do {
@@ -374,12 +385,18 @@ public final class StorageBlobClient: PipelineClient {
                         decoder: decoder,
                         delegate: self
                     )
-                    completion(.success(paged), httpResponse)
+                    DispatchQueue.main.async {
+                        completion(.success(paged), httpResponse)
+                    }
                 } catch {
-                    completion(.failure(error), httpResponse)
+                    DispatchQueue.main.async {
+                        completion(.failure(error), httpResponse)
+                    }
                 }
             case let .failure(error):
-                completion(.failure(error), httpResponse)
+                DispatchQueue.main.async {
+                    completion(.failure(error), httpResponse)
+                }
             }
         }
     }
@@ -419,9 +436,13 @@ public final class StorageBlobClient: PipelineClient {
         downloader.initialRequest { result, httpResponse in
             switch result {
             case .success:
-                completion(.success(downloader), httpResponse)
+                DispatchQueue.main.async {
+                    completion(.success(downloader), httpResponse)
+                }
             case let .failure(error):
-                completion(.failure(error), httpResponse)
+                DispatchQueue.main.async {
+                    completion(.failure(error), httpResponse)
+                }
             }
         }
     }
@@ -464,9 +485,13 @@ public final class StorageBlobClient: PipelineClient {
         uploader.next { result, httpResponse in
             switch result {
             case .success:
-                completion(.success(uploader), httpResponse)
+                DispatchQueue.main.async {
+                    completion(.success(uploader), httpResponse)
+                }
             case let .failure(error):
-                completion(.failure(error), httpResponse)
+                DispatchQueue.main.async {
+                    completion(.failure(error), httpResponse)
+                }
             }
         }
     }
@@ -595,22 +620,34 @@ extension StorageBlobClient: TransferDelegate {
         didUpdateWithState state: TransferState,
         andProgress progress: Float?
     ) {
-        transferDelegate?.transfer(transfer, didUpdateWithState: state, andProgress: progress)
+        guard let delegate = transferDelegate else { return }
+        DispatchQueue.main.async {
+            delegate.transfer(transfer, didUpdateWithState: state, andProgress: progress)
+        }
     }
 
     /// :nodoc:
     public func transfersDidUpdate(_ transfers: [Transfer]) {
-        transferDelegate?.transfersDidUpdate(transfers)
+        guard let delegate = transferDelegate else { return }
+        DispatchQueue.main.async {
+            delegate.transfersDidUpdate(transfers)
+        }
     }
 
     /// :nodoc:
     public func transfer(_ transfer: Transfer, didFailWithError error: Error) {
-        transferDelegate?.transfer(transfer, didFailWithError: error)
+        guard let delegate = transferDelegate else { return }
+        DispatchQueue.main.async {
+            delegate.transfer(transfer, didFailWithError: error)
+        }
     }
 
     /// :nodoc:
     public func transferDidComplete(_ transfer: Transfer) {
-        transferDelegate?.transferDidComplete(transfer)
+        guard let delegate = transferDelegate else { return }
+        DispatchQueue.main.async {
+            delegate.transferDidComplete(transfer)
+        }
     }
 }
 

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -63,13 +63,13 @@ internal protocol TransferManager {
 /// A delegate to receive notifications about state changes for all transfers managed by a `StorageBlobClient`.
 public protocol TransferDelegate: AnyObject {
     /// A transfer's state has changed, and progress may be reported.
-    func transfer(_: Transfer, didUpdateWithState: TransferState, andProgress: Float?)
+    func transfer(_ transfer: Transfer, didUpdateWithState state: TransferState, andProgress progress: Float?)
     /// A batch of transfers have changed.
-    func transfersDidUpdate(_: [Transfer])
+    func transfersDidUpdate(_ tranfers: [Transfer])
     /// A transfer has failed.
-    func transfer(_: Transfer, didFailWithError: Error)
+    func transfer(_ transfer: Transfer, didFailWithError error: Error)
     /// A transfer has completed.
-    func transferDidComplete(_: Transfer)
+    func transferDidComplete(_ transfer: Transfer)
 }
 
 // MARK: Extensions

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
@@ -32,7 +32,7 @@ extension URLSessionTransferManager: TransferDelegate {
     func transfer(_ transfer: Transfer, didUpdateWithState state: TransferState, andProgress progress: Float?) {
         DispatchQueue.main.async {
             guard let restorationId = (transfer as? TransferImpl)?.clientRestorationId else { return }
-            let delegate = client(forRestorationId: restorationId) as? TransferDelegate
+            let delegate = self.client(forRestorationId: restorationId) as? TransferDelegate
             switch state {
             case .failed:
                 // Block transfers should propagate up to their BlobTransfer and only notify that the
@@ -67,7 +67,7 @@ extension URLSessionTransferManager: TransferDelegate {
                 }
             }
             if let context = (transfer as? NSManagedObject)?.managedObjectContext {
-                save(context: context)
+                self.save(context: context)
             }
         }
     }
@@ -76,14 +76,14 @@ extension URLSessionTransferManager: TransferDelegate {
         DispatchQueue.main.async {
             let restorationIds = transfers.compactMap { ($0 as? TransferImpl)?.clientRestorationId }
             for restorationId in Set(restorationIds) {
-                guard let delegate = client(forRestorationId: restorationId) as? TransferDelegate else { continue }
+                guard let delegate = self.client(forRestorationId: restorationId) as? TransferDelegate else { continue }
                 let transfersForId = transfers.filter { ($0 as? TransferImpl)?.clientRestorationId == restorationId }
                 delegate.transfersDidUpdate(transfersForId)
 
                 // get the minimal set of unique MOCs and save them
                 let contexts = transfersForId.compactMap { ($0 as? NSManagedObject)?.managedObjectContext }
                 for context in Set(contexts) {
-                    save(context: context)
+                    self.save(context: context)
                 }
             }
         }
@@ -95,7 +95,7 @@ extension URLSessionTransferManager: TransferDelegate {
         DispatchQueue.main.async {
             delegate.transferDidComplete(transfer)
             if let context = (transfer as? NSManagedObject)?.managedObjectContext {
-                save(context: context)
+                self.save(context: context)
             }
         }
     }
@@ -106,7 +106,7 @@ extension URLSessionTransferManager: TransferDelegate {
         DispatchQueue.main.async {
             delegate.transfer(transfer, didFailWithError: error)
             if let context = (transfer as? NSManagedObject)?.managedObjectContext {
-                save(context: context)
+                self.save(context: context)
             }
         }
     }

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
@@ -30,57 +30,61 @@ import Foundation
 
 extension URLSessionTransferManager: TransferDelegate {
     func transfer(_ transfer: Transfer, didUpdateWithState state: TransferState, andProgress progress: Float?) {
-        guard let restorationId = (transfer as? TransferImpl)?.clientRestorationId else { return }
-        let delegate = client(forRestorationId: restorationId) as? TransferDelegate
-        switch state {
-        case .failed:
-            // Block transfers should propagate up to their BlobTransfer and only notify that the
-            // entire Blob transfer failed.
-            if let transferError = (transfer as? BlobTransfer)?.error as NSError? {
-                if [-1009, -1005].contains(transferError.code) {
-                    transfer.pause()
+        DispatchQueue.main.async {
+            guard let restorationId = (transfer as? TransferImpl)?.clientRestorationId else { return }
+            let delegate = client(forRestorationId: restorationId) as? TransferDelegate
+            switch state {
+            case .failed:
+                // Block transfers should propagate up to their BlobTransfer and only notify that the
+                // entire Blob transfer failed.
+                if let transferError = (transfer as? BlobTransfer)?.error as NSError? {
+                    if [-1009, -1005].contains(transferError.code) {
+                        transfer.pause()
+                    } else {
+                        delegate?.transfer(transfer, didFailWithError: transferError)
+                    }
                 } else {
-                    delegate?.transfer(transfer, didFailWithError: transferError)
-                }
-            } else {
-                // ignore BlockTransfer failures
-                return
-            }
-        case .complete:
-            delegate?.transferDidComplete(transfer)
-        case .paused:
-            delegate?.transfer(transfer, didUpdateWithState: state, andProgress: nil)
-        default:
-            if let blobTransfer = transfer as? BlobTransfer {
-                let progress = blobTransfer.progress
-
-                // avoid saving the context or sending multiple messages when the progress has not actually changed
-                if blobTransfer.currentProgress < progress {
-                    blobTransfer.currentProgress = progress
-                    delegate?.transfer(transfer, didUpdateWithState: state, andProgress: progress)
-                } else {
+                    // ignore BlockTransfer failures
                     return
                 }
-            } else {
+            case .complete:
+                delegate?.transferDidComplete(transfer)
+            case .paused:
                 delegate?.transfer(transfer, didUpdateWithState: state, andProgress: nil)
+            default:
+                if let blobTransfer = transfer as? BlobTransfer {
+                    let progress = blobTransfer.progress
+
+                    // avoid saving the context or sending multiple messages when the progress has not actually changed
+                    if blobTransfer.currentProgress < progress {
+                        blobTransfer.currentProgress = progress
+                        delegate?.transfer(transfer, didUpdateWithState: state, andProgress: progress)
+                    } else {
+                        return
+                    }
+                } else {
+                    delegate?.transfer(transfer, didUpdateWithState: state, andProgress: nil)
+                }
             }
-        }
-        if let context = (transfer as? NSManagedObject)?.managedObjectContext {
-            save(context: context)
+            if let context = (transfer as? NSManagedObject)?.managedObjectContext {
+                save(context: context)
+            }
         }
     }
 
     func transfersDidUpdate(_ transfers: [Transfer]) {
-        let restorationIds = transfers.compactMap { ($0 as? TransferImpl)?.clientRestorationId }
-        for restorationId in Set(restorationIds) {
-            guard let delegate = client(forRestorationId: restorationId) as? TransferDelegate else { continue }
-            let transfersForId = transfers.filter { ($0 as? TransferImpl)?.clientRestorationId == restorationId }
-            delegate.transfersDidUpdate(transfersForId)
+        DispatchQueue.main.async {
+            let restorationIds = transfers.compactMap { ($0 as? TransferImpl)?.clientRestorationId }
+            for restorationId in Set(restorationIds) {
+                guard let delegate = client(forRestorationId: restorationId) as? TransferDelegate else { continue }
+                let transfersForId = transfers.filter { ($0 as? TransferImpl)?.clientRestorationId == restorationId }
+                delegate.transfersDidUpdate(transfersForId)
 
-            // get the minimal set of unique MOCs and save them
-            let contexts = transfersForId.compactMap { ($0 as? NSManagedObject)?.managedObjectContext }
-            for context in Set(contexts) {
-                save(context: context)
+                // get the minimal set of unique MOCs and save them
+                let contexts = transfersForId.compactMap { ($0 as? NSManagedObject)?.managedObjectContext }
+                for context in Set(contexts) {
+                    save(context: context)
+                }
             }
         }
     }
@@ -88,18 +92,22 @@ extension URLSessionTransferManager: TransferDelegate {
     func transferDidComplete(_ transfer: Transfer) {
         guard let restorationId = (transfer as? TransferImpl)?.clientRestorationId else { return }
         guard let delegate = client(forRestorationId: restorationId) as? TransferDelegate else { return }
-        delegate.transferDidComplete(transfer)
-        if let context = (transfer as? NSManagedObject)?.managedObjectContext {
-            save(context: context)
+        DispatchQueue.main.async {
+            delegate.transferDidComplete(transfer)
+            if let context = (transfer as? NSManagedObject)?.managedObjectContext {
+                save(context: context)
+            }
         }
     }
 
     func transfer(_ transfer: Transfer, didFailWithError error: Error) {
         guard let restorationId = (transfer as? TransferImpl)?.clientRestorationId else { return }
         guard let delegate = client(forRestorationId: restorationId) as? TransferDelegate else { return }
-        delegate.transfer(transfer, didFailWithError: error)
-        if let context = (transfer as? NSManagedObject)?.managedObjectContext {
-            save(context: context)
+        DispatchQueue.main.async {
+            delegate.transfer(transfer, didFailWithError: error)
+            if let context = (transfer as? NSManagedObject)?.managedObjectContext {
+                save(context: context)
+            }
         }
     }
 }


### PR DESCRIPTION
- Simplifies client code by having the SDK invoke all completion handlers and delegate callbacks on the main DispatchQueue. 
- Restore the recommended internal labels for the `TransferDelegate` protocol based on UX study feedback.