### PR TITLE
Remove Copyable from Request

### DIFF
--- a/sdk/core/AzureCore/Source/Pipeline/PipelineRequest.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/PipelineRequest.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-public final class PipelineRequest: Copyable, PipelineContextSupporting {
+public final class PipelineRequest: PipelineContextSupporting {
     // MARK: Properties
 
     public var httpRequest: HTTPRequest
@@ -44,9 +44,5 @@ public final class PipelineRequest: Copyable, PipelineContextSupporting {
         self.httpRequest = request
         self.logger = logger
         self.context = context
-    }
-
-    public required convenience init(copy: PipelineRequest) {
-        self.init(request: copy.httpRequest, logger: copy.logger, context: copy.context)
     }
 }

--- a/sdk/core/AzureCore/Tests/PipelineRequestTests.swift
+++ b/sdk/core/AzureCore/Tests/PipelineRequestTests.swift
@@ -29,16 +29,6 @@ import XCTest
 
 // swiftlint:disable force_try
 class PipelineRequestTests: XCTestCase {
-    func test_PipelineRequest_CanBeCopied() {
-        let logger = ClientLoggers.default()
-        let httpRequest = try! HTTPRequest(method: .get, url: "https://www.contoso.com", headers: [:])
-        let originalRequest = PipelineRequest(request: httpRequest, logger: logger)
-        let copyRequest = originalRequest.copy()
-        XCTAssertFalse(originalRequest === copyRequest)
-        // FIXME: The copy should be a deep copy
-        XCTAssertFalse(originalRequest.httpRequest === copyRequest.httpRequest)
-    }
-
     func test_PipelineContext_CanAddAndAccessValues() {
         let logger = ClientLoggers.default()
         let httpRequest = try! HTTPRequest(method: .get, url: "https://www.contoso.com", headers: [:])


### PR DESCRIPTION
It's no longer used.

We should probably file an issue to plumb through both Request and Response as `inout` parameters so they can be modified by the policies as needed, rather than needing to make a copy in order to change them.