### PR TITLE
PagedCollection updates

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -86,10 +86,8 @@ class BlobDownloadViewController: UIViewController, MSALInteractiveDelegate {
     private func loadMoreSettings() {
         dataSource?.nextPage { result in
             switch result {
-            case let .success(data):
-                if data != nil {
-                    self.tableView.reloadData()
-                }
+            case .success:
+                self.tableView.reloadData()
             case let .failure(error):
                 self.showAlert(error: error)
             }

--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -36,7 +36,6 @@ import UIKit
 
 class BlobDownloadViewController: UIViewController, MSALInteractiveDelegate {
     private var dataSource: PagedCollection<BlobItem>?
-    private var noMoreData = false
 
     @IBOutlet var tableView: UITableView!
 
@@ -79,25 +78,20 @@ class BlobDownloadViewController: UIViewController, MSALInteractiveDelegate {
                 self.tableView.reloadData()
             case let .failure(error):
                 self.showAlert(error: error)
-                self.noMoreData = true
             }
         }
     }
 
     /// Uses asynchronous "nextPage" method to fetch the next page of results and update the table view.
     private func loadMoreSettings() {
-        guard noMoreData == false else { return }
         dataSource?.nextPage { result in
             switch result {
             case let .success(data):
                 if data != nil {
                     self.tableView.reloadData()
-                } else {
-                    self.noMoreData = true
                 }
             case let .failure(error):
                 self.showAlert(error: error)
-                self.noMoreData = true
             }
         }
     }
@@ -166,7 +160,7 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
         }
 
         // load next page if at the end of the current list
-        if indexPath.row == data.count - 1, noMoreData == false {
+        if indexPath.row == data.count - 1 {
             loadMoreSettings()
         }
         return cell

--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -173,7 +173,10 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
 
         let manager = FileManager.default
 
-        if let existingTransfer = blobClient.downloads.firstWith(blobName: blobName) {
+        if let existingTransfer = blobClient.downloads.firstWith(
+            containerName: AppConstants.videoContainer,
+            blobName: blobName
+        ) {
             // if transfer exists and is complete, open file, otherwise ignore
             if let destinationUrl = existingTransfer.destinationUrl,
                 manager.fileExists(atPath: destinationUrl.path),

--- a/sdk/core/AzureCore/Source/DataStructures/Collections.swift
+++ b/sdk/core/AzureCore/Source/DataStructures/Collections.swift
@@ -172,7 +172,7 @@ public class PagedCollection<SingleElement: Codable>: PagedCollectionDelegate {
     // MARK: Public Methods
 
     /// Retrieves the next page of results asynchronously.
-    public func nextPage(then completion: @escaping Continuation<Element?>) {
+    public func nextPage(then completion: @escaping Continuation<Element>) {
         // exit if there is no valid continuation token
         guard let continuationToken = continuationToken,
             continuationToken != "" else {
@@ -217,14 +217,16 @@ public class PagedCollection<SingleElement: Codable>: PagedCollectionDelegate {
                 return
             }
             self.iteratorIndex = 0
-            DispatchQueue.main.async {
-                completion(.success(self.pageItems))
+            if let pageItems = self.pageItems {
+                DispatchQueue.main.async {
+                    completion(.success(pageItems))
+                }
             }
         }
     }
 
     /// Retrieves the next item in the collection, automatically fetching new pages when needed.
-    public func nextItem(then completion: @escaping Continuation<SingleElement?>) {
+    public func nextItem(then completion: @escaping Continuation<SingleElement>) {
         guard let pageItems = pageItems else {
             // do not call the completion handler if there is no data
             return
@@ -237,12 +239,10 @@ public class PagedCollection<SingleElement: Codable>: PagedCollectionDelegate {
                         completion(.failure(error))
                     }
                 case let .success(newPage):
-                    if let newPage = newPage {
-                        // since we return the first new item, the next iteration should start with the second item.
-                        self.iteratorIndex = 1
-                        DispatchQueue.main.async {
-                            completion(.success(newPage[0]))
-                        }
+                    // since we return the first new item, the next iteration should start with the second item.
+                    self.iteratorIndex = 1
+                    DispatchQueue.main.async {
+                        completion(.success(newPage[0]))
                     }
                 }
             }

--- a/sdk/core/AzureCore/Tests/CollectionsTests.swift
+++ b/sdk/core/AzureCore/Tests/CollectionsTests.swift
@@ -146,7 +146,7 @@ class CollectionsTests: XCTestCase {
             paged.nextItem { result in
                 switch result {
                 case let .success(item):
-                    XCTAssertEqual(item?.id, index + 1)
+                    XCTAssertEqual(item.id, index + 1)
                 case let .failure(error):
                     XCTFail(error.localizedDescription)
                 }

--- a/sdk/storage/AzureStorageBlob/Source/DataStructures/TransferCollection.swift
+++ b/sdk/storage/AzureStorageBlob/Source/DataStructures/TransferCollection.swift
@@ -96,12 +96,14 @@ public struct TransferCollection {
     ///   uploads this is the source.
     ///   - state: The current state of the transfer.
     public func firstWith(
-        containerName _: String? = nil,
-        blobName _: String? = nil,
-        localUrl _: LocalURL? = nil,
-        state _: TransferState? = nil
+        containerName: String? = nil,
+        blobName: String? = nil,
+        localUrl: LocalURL? = nil,
+        state: TransferState? = nil
     ) -> BlobTransfer? {
-        return items.first { match($0) }
+        return items.first { transfer in
+            match(transfer, containerName: containerName, blobName: blobName, localUrl: localUrl, state: state)
+        }
     }
 
     private func match(
@@ -125,11 +127,11 @@ public struct TransferCollection {
                 url.path.hasSuffix(blobName) else { return false }
         }
 
-        if let containerName = containerName {
+        if var containerName = containerName {
+            containerName = containerName.hasPrefix("/") ? containerName : "/\(containerName)"
             guard let url = transfer.transferType == .download ? transfer.source : transfer.destination,
                 url.path.hasPrefix(containerName) else { return false }
         }
-
         return true
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/DataStructures/TransferCollection.swift
+++ b/sdk/storage/AzureStorageBlob/Source/DataStructures/TransferCollection.swift
@@ -78,12 +78,14 @@ public struct TransferCollection {
     ///   uploads this is the source.
     ///   - state: The current state of the transfer.
     public func filterWhere(
-        containerName _: String? = nil,
-        blobName _: String? = nil,
-        localUrl _: LocalURL? = nil,
-        state _: TransferState? = nil
+        containerName: String? = nil,
+        blobName: String? = nil,
+        localUrl: LocalURL? = nil,
+        state: TransferState? = nil
     ) -> TransferCollection {
-        return TransferCollection(items.filter { match($0) })
+        return TransferCollection(items.filter { transfer in
+            match(transfer, containerName: containerName, blobName: blobName, localUrl: localUrl, state: state)
+        })
     }
 
     /// Get the first transfer in this `TransferCollection` that matches all of the provided filter values.


### PR DESCRIPTION
This PR:

- Fixes #303 by adding an `isExhausted` property the app developer can check.
- Wraps completion handler calls in `nextPage` and `nextItem` in appropriate calls to dispatch onto the main queue to eliminate the need for the developer to do this.
- The default behavior for "no data received" is to simply return rather than call the completion handler with `nil` data. This allows the user's app to do the right thing when the collection is exhausted without them having to manually check `isExhausted`. The property is still supplied as the app developer may want to affirmatively check this.