### PR TITLE
Use TransferProgress uniformly for progress.

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -156,7 +156,7 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
             blobName: blobName
         ) {
             cell.backgroundColor = transfer.state.color
-            cell.progressBar.progress = transfer.progress
+            cell.progressBar.progress = transfer.progress.asFloat
         }
 
         // load next page if at the end of the current list

--- a/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
@@ -182,7 +182,7 @@ extension BlobUploadViewController: UICollectionViewDelegate, UICollectionViewDa
             // Match any blobs to existing transfers.
             // Update upload map and progress.
             cell.backgroundColor = transfer.state.color
-            cell.progressBar.progress = transfer.progress
+            cell.progressBar.progress = transfer.progress.asFloat
         }
         return cell
     }

--- a/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobUploadViewController.swift
@@ -249,7 +249,7 @@ extension BlobUploadViewController: StorageBlobClientDelegate {
         _: StorageBlobClient,
         didUpdateTransfer transfer: BlobTransfer,
         withState _: TransferState,
-        andProgress _: Float?
+        andProgress _: TransferProgress?
     ) {
         if transfer.transferType == .upload {
             collectionView.reloadData()

--- a/sdk/storage/AzureStorageBlob/Source/Data/AzureStorage.xcdatamodeld/AzureStorage.xcdatamodel/contents
+++ b/sdk/storage/AzureStorageBlob/Source/Data/AzureStorage.xcdatamodeld/AzureStorage.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E287" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="BlobTransfer" representedClassName=".BlobTransfer" syncable="YES">
+        <attribute name="bytesTransferred" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="clientRestorationId" attributeType="String"/>
         <attribute name="currentProgress" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="destination" attributeType="URI"/>
@@ -15,6 +16,7 @@
         <attribute name="source" attributeType="URI"/>
         <attribute name="startRange" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="totalBlocks" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalBytesToTransfer" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="blocks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="BlockTransfer" inverseName="parent" inverseEntity="BlockTransfer"/>
         <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MultiBlobTransfer" inverseName="blobs" inverseEntity="MultiBlobTransfer"/>
     </entity>
@@ -32,7 +34,7 @@
         <relationship name="blobs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="BlobTransfer" inverseName="parent" inverseEntity="BlobTransfer"/>
     </entity>
     <elements>
-        <element name="BlobTransfer" positionX="-369" positionY="-72" width="128" height="283"/>
+        <element name="BlobTransfer" positionX="-369" positionY="-72" width="128" height="313"/>
         <element name="BlockTransfer" positionX="-634.12890625" positionY="78.31640625" width="128" height="118"/>
         <element name="MultiBlobTransfer" positionX="9" positionY="108" width="128" height="103"/>
     </elements>

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataClass.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataClass.swift
@@ -48,11 +48,10 @@ public class BlobTransfer: NSManagedObject, Transfer {
         return Int64(transfers.filter { $0.state != .complete }.count)
     }
 
-    // TODO: Convert this to return a TransferProgress object
     /// The current progress of the transfer, calculated as the number of completed blocks divided by the total number
     /// of blocks that comprise the blob transfer.
-    public var progress: Float {
-        return Float(Int64(transfers.count) - incompleteBlocks) / Float(transfers.count)
+    public var progress: TransferProgress {
+        return TransferProgress(bytes: Int(bytesTransferred), totalBytes: Int(totalBytesToTransfer))
     }
 
     /// A debug representation of the transfer.

--- a/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/BlobTransfer+CoreDataProperties.swift
@@ -53,6 +53,8 @@ extension BlobTransfer {
     @NSManaged internal var totalBlocks: Int64
     @NSManaged internal var blocks: NSSet?
     @NSManaged internal var currentProgress: Float
+    @NSManaged internal var bytesTransferred: Int64
+    @NSManaged internal var totalBytesToTransfer: Int64
     @NSManaged internal var parent: MultiBlobTransfer?
     @NSManaged internal var rawOptions: String?
     @NSManaged internal var rawProperties: String?

--- a/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Data/Transfer.swift
@@ -42,6 +42,12 @@ public struct TransferProgress {
 
     /// Percentage of the transfer that is complete, as a Float between 0 and 1.
     public var asFloat: Float {
+        // Returning NaN sometimes results in progress appearing as 100% when it shouldn't.
+        // This ensures progress will report 0%.
+        // TODO: Debug concurrency instabilitites triggering this
+        // assert(bytes <= totalBytes, "Transferred bytes unexpectedly > than total bytes.")
+        if totalBytes <= 0 { return 0 }
+        if bytes == totalBytes { return 1.0 }
         return Float(bytes) / Float(totalBytes)
     }
 }

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlobDownloadOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlobDownloadOperations.swift
@@ -100,16 +100,11 @@ internal class BlobDownloadInitialOperation: TransferOperation {
 
         let group = DispatchGroup()
         group.enter()
-        downloader.initialRequest { result, httpResponse in
+        downloader.initialRequest { result, _ in
             switch result {
             case .success:
-                guard let responseHeaders = httpResponse?.headers else {
-                    assertionFailure("Response headers not found.")
-                    return
-                }
-                let blobProperties = BlobProperties(from: responseHeaders)
                 parent.totalBytesToTransfer = Int64(downloader.totalSize)
-                parent.bytesTransferred += Int64(blobProperties.contentLength ?? 0)
+                parent.bytesTransferred = Int64(downloader.progress)
                 transfer.state = .complete
                 self.queueRemainingBlocks(forTransfer: parent)
                 self.notifyDelegate(withTransfer: parent)

--- a/sdk/storage/AzureStorageBlob/Source/Operation/BlockOperations.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Operation/BlockOperations.swift
@@ -77,8 +77,9 @@ internal class BlockOperation: TransferOperation {
                         return
                     }
                     let blobProperties = BlobProperties(from: responseHeaders)
-                    let contentLength = blobProperties.contentLength ?? 0
-                    downloader.progress += contentLength
+                    let bytesTransferred = (blobProperties.contentLength ?? 1) - 1
+                    downloader.progress += bytesTransferred
+                    parent.bytesTransferred += Int64(bytesTransferred)
                     transfer.state = .complete
                     self.notifyDelegate(withTransfer: parent)
                 case let .failure(error):

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient+Extensions.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient+Extensions.swift
@@ -45,10 +45,15 @@ extension StorageBlobClient: TransferDelegate {
     public func transfer(
         _ transfer: Transfer,
         didUpdateWithState state: TransferState,
-        andProgress progress: TransferProgress?
+        andProgress _: TransferProgress?
     ) {
         if let blobTransfer = transfer as? BlobTransfer {
-            delegate?.blobClient(self, didUpdateTransfer: blobTransfer, withState: state, andProgress: progress)
+            delegate?.blobClient(
+                self,
+                didUpdateTransfer: blobTransfer,
+                withState: state,
+                andProgress: blobTransfer.progress
+            )
         }
     }
 

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient+Extensions.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient+Extensions.swift
@@ -45,7 +45,7 @@ extension StorageBlobClient: TransferDelegate {
     public func transfer(
         _ transfer: Transfer,
         didUpdateWithState state: TransferState,
-        andProgress progress: Float?
+        andProgress progress: TransferProgress?
     ) {
         if let blobTransfer = transfer as? BlobTransfer {
             delegate?.blobClient(self, didUpdateTransfer: blobTransfer, withState: state, andProgress: progress)

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
@@ -32,7 +32,7 @@ public protocol StorageBlobClientDelegate: AnyObject {
     ///   - client: The `StorageBlobClient` associated with the transfer.
     ///   - transfer: The `BlobTransfer` that has changed.
     ///   - state: The `TransferState` of the blob transfer.
-    ///   - progress: The `TransferProgress` of the blob transfer, if relevant.
+    ///   - progress: The `TransferProgress` of the blob transfer.
     func blobClient(
         _ client: StorageBlobClient,
         didUpdateTransfer transfer: BlobTransfer,

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
@@ -29,7 +29,7 @@ import Foundation
 public protocol StorageBlobClientDelegate: AnyObject {
     /// A blob transfer's state and/or progress have changed.
     /// - Parameters:
-    ///   - client: The `BlobStorageClient` associated with the transfer.
+    ///   - client: The `StorageBlobClient` associated with the transfer.
     ///   - transfer: The `BlobTransfer` that has changed.
     ///   - state: The `TransferState` of the blob transfer.
     ///   - progress: The `TransferProgress` of the blob transfer, if relevant.
@@ -42,13 +42,13 @@ public protocol StorageBlobClientDelegate: AnyObject {
 
     /// A blob transfer has finished.
     /// - Parameters:
-    ///   - client: The `BlobStorageClient` associated with the transfer.
+    ///   - client: The `StorageBlobClient` associated with the transfer.
     ///   - transfer: The `BlobTransfer` that has completed.
     func blobClient(_ client: StorageBlobClient, didCompleteTransfer transfer: BlobTransfer)
 
     /// A blob transfer has failed.
     /// - Parameters:
-    ///   - client: The `BlobStorageClient` associated with the transfer.
+    ///   - client: The `StorageBlobClient` associated with the transfer.
     ///   - transfer: The `BlobTransfer` that failed.
     ///   - error: The `Error` associated with the failure.
     func blobClient(_ client: StorageBlobClient, didFailTransfer transfer: BlobTransfer, withError error: Error)

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
@@ -37,7 +37,7 @@ public protocol StorageBlobClientDelegate: AnyObject {
         _ client: StorageBlobClient,
         didUpdateTransfer transfer: BlobTransfer,
         withState state: TransferState,
-        andProgress progress: TransferProgress?
+        andProgress progress: TransferProgress
     )
 
     /// A blob transfer has finished.
@@ -60,7 +60,7 @@ extension StorageBlobClientDelegate {
         _: StorageBlobClient,
         didUpdateTransfer _: BlobTransfer,
         withState _: TransferState,
-        andProgress _: TransferProgress?
+        andProgress _: TransferProgress
     ) {}
     public func blobClient(_: StorageBlobClient, didCompleteTransfer _: BlobTransfer) {}
     public func blobClient(_: StorageBlobClient, didFailTransfer _: BlobTransfer, withError _: Error) {}

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
@@ -27,13 +27,30 @@
 import Foundation
 
 public protocol StorageBlobClientDelegate: AnyObject {
+    /// A blob transfer's state and/or progress have changed.
+    /// - Parameters:
+    ///   - client: The `BlobStorageClient` associated with the transfer.
+    ///   - transfer: The `BlobTransfer` that has changed.
+    ///   - state: The `TransferState` of the blob transfer.
+    ///   - progress: The `TransferProgress` of the blob transfer, if relevant.
     func blobClient(
         _ client: StorageBlobClient,
         didUpdateTransfer transfer: BlobTransfer,
         withState state: TransferState,
         andProgress progress: TransferProgress?
     )
+
+    /// A blob transfer has finished.
+    /// - Parameters:
+    ///   - client: The `BlobStorageClient` associated with the transfer.
+    ///   - transfer: The `BlobTransfer` that has completed.
     func blobClient(_ client: StorageBlobClient, didCompleteTransfer transfer: BlobTransfer)
+
+    /// A blob transfer has failed.
+    /// - Parameters:
+    ///   - client: The `BlobStorageClient` associated with the transfer.
+    ///   - transfer: The `BlobTransfer` that failed.
+    ///   - error: The `Error` associated with the failure.
     func blobClient(_ client: StorageBlobClient, didFailTransfer transfer: BlobTransfer, withError error: Error)
 }
 

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClientDelegate.swift
@@ -31,7 +31,7 @@ public protocol StorageBlobClientDelegate: AnyObject {
         _ client: StorageBlobClient,
         didUpdateTransfer transfer: BlobTransfer,
         withState state: TransferState,
-        andProgress progress: Float?
+        andProgress progress: TransferProgress?
     )
     func blobClient(_ client: StorageBlobClient, didCompleteTransfer transfer: BlobTransfer)
     func blobClient(_ client: StorageBlobClient, didFailTransfer transfer: BlobTransfer, withError error: Error)
@@ -43,7 +43,7 @@ extension StorageBlobClientDelegate {
         _: StorageBlobClient,
         didUpdateTransfer _: BlobTransfer,
         withState _: TransferState,
-        andProgress _: Float?
+        andProgress _: TransferProgress?
     ) {}
     public func blobClient(_: StorageBlobClient, didCompleteTransfer _: BlobTransfer) {}
     public func blobClient(_: StorageBlobClient, didFailTransfer _: BlobTransfer, withError _: Error) {}

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -432,7 +432,7 @@ internal class BlobStreamDownloader: BlobDownloader {
                     // extract the file size from the content range. If a specific size request was
                     // not made, then the request is for the entire file.
                     let blobSize = try self.parseLength(fromContentRange: contentRange)
-                    self.totalSize = blobSize
+                    self.totalSize = blobSize - 1
                     self.progress += blobProperties.contentLength ?? 0
                     self.blobProperties = blobProperties
 

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -58,14 +58,24 @@ internal protocol TransferManager {
 
 /// A delegate to receive notifications about state changes for all transfers managed by a `StorageBlobClient`.
 public protocol TransferDelegate: AnyObject {
-    /// A transfer's state has changed, and progress may be reported.
+    /// A transfer's state and/or progress have changed.
+    /// - Parameters:
+    ///   - transfer: The `Transfer` object that updated.
+    ///   - state: The `TransferState` of the updated transfer.
+    ///   - progress: The `TransferProgress` of the updated transfer, if relevant.
     func transfer(
         _ transfer: Transfer,
         didUpdateWithState state: TransferState,
         andProgress progress: TransferProgress?
     )
+
     /// A transfer has failed.
+    /// - Parameters:
+    ///   - transfer: The `Transfer` object that failed.
+    ///   - error: The `Error` associated with the failure.
     func transfer(_ transfer: Transfer, didFailWithError error: Error)
-    /// A transfer has completed.
+
+    /// A transfer has finished.
+    /// - Parameter transfer: The `Transfer` object that finished.
     func transferDidComplete(_ transfer: Transfer)
 }

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -62,7 +62,7 @@ internal protocol TransferDelegate: AnyObject {
     /// - Parameters:
     ///   - transfer: The `Transfer` object that updated.
     ///   - state: The `TransferState` of the updated transfer.
-    ///   - progress: The `TransferProgress` of the updated transfer, if relevant.
+    ///   - progress: The `TransferProgress` of the updated transfer.
     func transfer(
         _ transfer: Transfer,
         didUpdateWithState state: TransferState,

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -50,7 +50,6 @@ internal protocol TransferManager {
     func cancel(transfer: TransferImpl)
     func pause(transfer: TransferImpl)
     func remove(transfer: TransferImpl)
-    // TODO: Resolve issue where handler can't be downcast
     func resume(transfer: TransferImpl, progressHandler: ((BlobTransfer) -> Void)?)
 
     func loadContext()
@@ -60,7 +59,11 @@ internal protocol TransferManager {
 /// A delegate to receive notifications about state changes for all transfers managed by a `StorageBlobClient`.
 public protocol TransferDelegate: AnyObject {
     /// A transfer's state has changed, and progress may be reported.
-    func transfer(_ transfer: Transfer, didUpdateWithState state: TransferState, andProgress progress: Float?)
+    func transfer(
+        _ transfer: Transfer,
+        didUpdateWithState state: TransferState,
+        andProgress progress: TransferProgress?
+    )
     /// A transfer has failed.
     func transfer(_ transfer: Transfer, didFailWithError error: Error)
     /// A transfer has completed.

--- a/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/TransferManager.swift
@@ -57,7 +57,7 @@ internal protocol TransferManager {
 }
 
 /// A delegate to receive notifications about state changes for all transfers managed by a `StorageBlobClient`.
-public protocol TransferDelegate: AnyObject {
+internal protocol TransferDelegate: AnyObject {
     /// A transfer's state and/or progress have changed.
     /// - Parameters:
     ///   - transfer: The `Transfer` object that updated.

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
@@ -29,7 +29,11 @@ import CoreData
 import Foundation
 
 extension URLSessionTransferManager: TransferDelegate {
-    func transfer(_ transfer: Transfer, didUpdateWithState state: TransferState, andProgress progress: Float?) {
+    func transfer(
+        _ transfer: Transfer,
+        didUpdateWithState state: TransferState,
+        andProgress progress: TransferProgress?
+    ) {
         DispatchQueue.main.async {
             guard let restorationId = (transfer as? TransferImpl)?.clientRestorationId else { return }
             switch state {

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager+TransferDelegate.swift
@@ -65,8 +65,8 @@ extension URLSessionTransferManager: TransferDelegate {
 
                     // avoid saving the context or sending multiple messages when the progress and/or state have not
                     // actually changed.
-                    if blobTransfer.currentProgress < progress {
-                        blobTransfer.currentProgress = progress
+                    if blobTransfer.currentProgress < progress.asFloat {
+                        blobTransfer.currentProgress = progress.asFloat
                         delegate?.transfer(transfer, didUpdateWithState: state, andProgress: progress)
                         blobTransfer.progressHandler?(blobTransfer)
                     } else if blobTransfer.previousState != state {

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -483,6 +483,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
                     properties: blobProperties,
                     options: uploadOptions
                 )
+                transfer.uploader?.progress = Int(transfer.bytesTransferred)
             case .download:
                 guard let sourceUrl = transfer.source else { return }
                 guard let destUrl = transfer.destination else { return }
@@ -494,6 +495,8 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
                     destination: destination,
                     options: transfer.downloadOptions
                 )
+                transfer.downloader?.progress = Int(transfer.bytesTransferred)
+                transfer.downloader?.totalSize = Int(transfer.totalBytesToTransfer)
             }
         } catch {
             client.logger.error(error.localizedDescription)

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -533,6 +533,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
         context.perform {
             if context.hasChanges {
                 do {
+                    print("SAVE CHANGES!")
                     try context.save()
                 } catch {
                     let nserror = error as NSError
@@ -540,6 +541,8 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
                     let errorMessage = "Unresolved error \(nserror.code): \(message)"
                     assertionFailure(errorMessage)
                 }
+            } else {
+                print("NO CHANGES")
             }
         }
     }

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -533,7 +533,6 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
         context.perform {
             if context.hasChanges {
                 do {
-                    print("SAVE CHANGES!")
                     try context.save()
                 } catch {
                     let nserror = error as NSError
@@ -541,8 +540,6 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
                     let errorMessage = "Unresolved error \(nserror.code): \(message)"
                     assertionFailure(errorMessage)
                 }
-            } else {
-                print("NO CHANGES")
             }
         }
     }


### PR DESCRIPTION
Closes #244.

Updates transfer manager methods to use the TransferProgress struct instead of a raw Float.