### PR TITLE
Error handling updates

### DIFF
--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -168,7 +168,7 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
 
     func downloadProgress(transfer: BlobTransfer) {
         guard transfer.state != .failed else {
-            let error = transfer.error ?? AzureError.sdk("An error occurred.")
+            let error = transfer.error ?? AzureSdkError("An error occurred.")
             showAlert(error: error)
             tableView.reloadData()
             return

--- a/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
+++ b/examples/AzureSDKDemoSwift/Source/BlobDownloadViewController.swift
@@ -168,7 +168,7 @@ extension BlobDownloadViewController: UITableViewDelegate, UITableViewDataSource
 
     func downloadProgress(transfer: BlobTransfer) {
         guard transfer.state != .failed else {
-            let error = transfer.error ?? AzureError.general("An error occurred.")
+            let error = transfer.error ?? AzureError.sdk("An error occurred.")
             showAlert(error: error)
             tableView.reloadData()
             return

--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -89,7 +89,7 @@ struct AppState {
     static func blobClient(withDelegate delegate: StorageBlobClientDelegate? = nil) throws -> StorageBlobClient {
         if AppState.internalBlobClient == nil {
             guard let application = AppState.application else {
-                let error = AzureError.general("Application is not initialized. Unable to create Blob Storage Client.")
+                let error = AzureError.sdk("Application is not initialized. Unable to create Blob Storage Client.")
                 throw error
             }
             let credential = MSALCredential(

--- a/examples/AzureSDKDemoSwift/Source/Common.swift
+++ b/examples/AzureSDKDemoSwift/Source/Common.swift
@@ -89,7 +89,7 @@ struct AppState {
     static func blobClient(withDelegate delegate: StorageBlobClientDelegate? = nil) throws -> StorageBlobClient {
         if AppState.internalBlobClient == nil {
             guard let application = AppState.application else {
-                let error = AzureError.sdk("Application is not initialized. Unable to create Blob Storage Client.")
+                let error = AzureSdkError("Application is not initialized. Unable to create Blob Storage Client.")
                 throw error
             }
             let credential = MSALCredential(

--- a/sdk/core/AzureCore/Source/DataStructures/Collections.swift
+++ b/sdk/core/AzureCore/Source/DataStructures/Collections.swift
@@ -188,7 +188,7 @@ public class PagedCollection<SingleElement: Codable> {
         codingKeys: PagedCodingKeys? = nil,
         decoder: JSONDecoder? = nil
     ) throws {
-        let noDataError = AzureError.sdk("Response data expected but not found.")
+        let noDataError = AzureSdkError("Response data expected but not found.")
         guard let data = data else { throw noDataError }
         self.client = client
         self.decoder = decoder ?? JSONDecoder()
@@ -204,7 +204,7 @@ public class PagedCollection<SingleElement: Codable> {
     public func nextPage(completionHandler: @escaping Continuation<Element>) {
         // exit if there is no valid continuation token
         guard let continuationToken = continuationToken, !self.isExhausted else {
-            let error = AzureError.general("Paged collection exhausted.")
+            let error = AzureSdkError("Paged collection exhausted.")
             completionHandler(.failure(error))
             return
         }
@@ -327,11 +327,11 @@ public class PagedCollection<SingleElement: Codable> {
     /// Deserializes the JSON payload to append the new items, update tracking of the "current page" of items
     /// and reset the per page iterator.
     private func update(with data: Data?) throws {
-        let noDataError = AzureError.sdk("Response data expected but not found.")
+        let noDataError = AzureSdkError("Response data expected but not found.")
         guard let data = data else { throw noDataError }
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { throw noDataError }
         let codingKeys = self.codingKeys
-        let notPagedError = AzureError.sdk("Paged response expected but not found.")
+        let notPagedError = AzureSdkError("Paged response expected but not found.")
         guard let itemJson = codingKeys.items(fromJson: json) else { throw notPagedError }
         continuationToken = codingKeys.continuationToken(fromJson: json)
 

--- a/sdk/core/AzureCore/Source/Errors.swift
+++ b/sdk/core/AzureCore/Source/Errors.swift
@@ -44,43 +44,26 @@ extension BaseError {
 }
 
 public enum AzureError: BaseError {
-    case general(_ message: String)
-    case fileSystem(_ message: String)
-    case serviceRequest(_ message: String)
-    case serviceResponse(_ message: String)
+    case sdk(_ message: String)
+    case service(_ message: String)
+    case system(_ message: String)
 
     var message: String {
         switch self {
-        case let .general(msg),
-             let .serviceRequest(msg),
-             let .fileSystem(msg),
-             let .serviceResponse(msg):
+        case let .sdk(msg),
+             let .service(msg),
+             let .system(msg):
             return msg
         }
     }
 }
 
-public enum HTTPResponseError: BaseError {
-    case general(_ message: String)
-    case decode(_ message: String)
-    case resourceExists(_ message: String)
-    case resourceNotFound(_ message: String)
-    case clientAuthentication(_ message: String)
-    case resourceModified(_ message: String)
-    case tooManyRedirects(_ message: String)
-    case statusCode(_ message: String)
-
-    public var message: String {
-        switch self {
-        case let .general(msg),
-             let .decode(msg),
-             let .resourceExists(msg),
-             let .resourceNotFound(msg),
-             let .clientAuthentication(msg),
-             let .resourceModified(msg),
-             let .tooManyRedirects(msg),
-             let .statusCode(msg):
-            return msg
+extension Error {
+    public var toAzureError: AzureError {
+        if self is AzureError {
+            // swiftlint:disable force_cast
+            return self as! AzureError
         }
+        return AzureError.system(localizedDescription)
     }
 }

--- a/sdk/core/AzureCore/Source/Pipeline/PipelineClient.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/PipelineClient.swift
@@ -97,7 +97,7 @@ open class PipelineClient {
                 let allowedStatusCodes = pipelineResponse.value(forKey: .allowedStatusCodes) as? [Int] ?? [200]
                 if !allowedStatusCodes.contains(httpResponse?.statusCode ?? -1) {
                     self.logError(withData: deserializedData)
-                    let error = HTTPResponseError.statusCode("Service returned invalid status code [\(statusCode)].")
+                    let error = AzureError.sdk("Service returned invalid status code [\(statusCode)].")
                     completionHandler(.failure(error), httpResponse)
                 } else {
                     if let deserialized = deserializedData {
@@ -107,7 +107,7 @@ open class PipelineClient {
                     }
                 }
             case let .failure(error):
-                completionHandler(.failure(error), httpResponse)
+                completionHandler(.failure(error.innerError), httpResponse)
             }
         }
     }

--- a/sdk/core/AzureCore/Source/Pipeline/PipelineClient.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/PipelineClient.swift
@@ -97,7 +97,7 @@ open class PipelineClient {
                 let allowedStatusCodes = pipelineResponse.value(forKey: .allowedStatusCodes) as? [Int] ?? [200]
                 if !allowedStatusCodes.contains(httpResponse?.statusCode ?? -1) {
                     self.logError(withData: deserializedData)
-                    let error = AzureError.sdk("Service returned invalid status code [\(statusCode)].")
+                    let error = AzureSdkError("Service returned invalid status code [\(statusCode)].")
                     completionHandler(.failure(error), httpResponse)
                 } else {
                     if let deserialized = deserializedData {

--- a/sdk/core/AzureCore/Source/Pipeline/PipelineError.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/PipelineError.swift
@@ -29,13 +29,13 @@ import Foundation
 public final class PipelineError: Error {
     // MARK: Properties
 
-    public var innerError: Error
+    public var innerError: AzureError
     public var pipelineResponse: PipelineResponse
 
     // MARK: Initializers
 
     init(fromError innerError: Error, pipelineResponse: PipelineResponse) {
-        self.innerError = innerError
+        self.innerError = innerError.toAzureError
         self.pipelineResponse = pipelineResponse
     }
 }

--- a/sdk/core/AzureCore/Source/Pipeline/PipelineStage.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/PipelineStage.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 public typealias ResultHandler<TSuccess, TError: Error> = (Result<TSuccess, TError>, HTTPResponse?) -> Void
-public typealias HTTPResultHandler<T> = ResultHandler<T, Error>
+public typealias HTTPResultHandler<T> = ResultHandler<T, AzureError>
 public typealias PipelineStageResultHandler = ResultHandler<PipelineResponse, PipelineError>
 public typealias OnRequestCompletionHandler = (PipelineRequest, Error?) -> Void
 public typealias OnResponseCompletionHandler = (PipelineResponse, Error?) -> Void
@@ -78,7 +78,7 @@ extension PipelineStage {
     }
 
     public func on(error: PipelineError, completionHandler: @escaping OnErrorCompletionHandler) {
-        completionHandler(error, false)
+        completionHandler(error.innerError, false)
     }
 
     public func process(
@@ -119,9 +119,9 @@ extension PipelineStage {
                         completionHandler(.success(response), httpResponse)
                     }
                 case let .failure(pipelineError):
-                    self.on(error: pipelineError) { error, handled in
+                    self.on(error: pipelineError) { _, handled in
                         if !handled {
-                            completionHandler(.failure(error), httpResponse)
+                            completionHandler(.failure(pipelineError), nil)
                             return
                         }
                     }

--- a/sdk/core/AzureCore/Source/Pipeline/PipelineStage.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/PipelineStage.swift
@@ -28,10 +28,10 @@ import Foundation
 
 public typealias ResultHandler<TSuccess, TError: Error> = (Result<TSuccess, TError>, HTTPResponse?) -> Void
 public typealias HTTPResultHandler<T> = ResultHandler<T, AzureError>
-public typealias PipelineStageResultHandler = ResultHandler<PipelineResponse, PipelineError>
-public typealias OnRequestCompletionHandler = (PipelineRequest, Error?) -> Void
-public typealias OnResponseCompletionHandler = (PipelineResponse, Error?) -> Void
-public typealias OnErrorCompletionHandler = (PipelineError, Bool) -> Void
+public typealias PipelineStageResultHandler = ResultHandler<PipelineResponse, AzureError>
+public typealias OnRequestCompletionHandler = (PipelineRequest, AzureError?) -> Void
+public typealias OnResponseCompletionHandler = (PipelineResponse, AzureError?) -> Void
+public typealias OnErrorCompletionHandler = (AzureError, Bool) -> Void
 
 /// Protocol for implementing pipeline stages.
 public protocol PipelineStage {
@@ -58,7 +58,7 @@ public protocol PipelineStage {
     ///   - error: The `PipelineError` input.
     ///   - completionHandler: A completion handler which forwards the error along with a boolean
     ///   that indicates whether the exception was handled or not.
-    func on(error: PipelineError, completionHandler: @escaping OnErrorCompletionHandler)
+    func on(error: AzureError, completionHandler: @escaping OnErrorCompletionHandler)
 
     /// Executes the policy method.
     /// - Parameters:
@@ -77,7 +77,7 @@ extension PipelineStage {
         completionHandler(response, nil)
     }
 
-    public func on(error: PipelineError, completionHandler: @escaping OnErrorCompletionHandler) {
+    public func on(error: AzureError, completionHandler: @escaping OnErrorCompletionHandler) {
         completionHandler(error.innerError, false)
     }
 

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/AuthenticationPolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/AuthenticationPolicy.swift
@@ -25,7 +25,7 @@
 // --------------------------------------------------------------------------
 import Foundation
 
-public typealias TokenCompletionHandler = (AccessToken?, Error?) -> Void
+public typealias TokenCompletionHandler = (AccessToken?, AzureError?) -> Void
 
 public struct AccessToken {
     // MARK: Properties

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
@@ -218,7 +218,7 @@ public class ContentDecodePolicy: PipelineStage {
             jsonData = try JSONSerialization.data(withJSONObject: arrayObj, options: [])
         }
         guard let finalJsonData = jsonData else {
-            throw HTTPResponseError.decode("Failure decoding XML.")
+            throw AzureError.sdk("Failure decoding XML.")
         }
         return try JSONSerialization.jsonObject(with: finalJsonData, options: []) as AnyObject
     }

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
@@ -201,7 +201,7 @@ public class ContentDecodePolicy: PipelineStage {
         } catch {
             let errorMessage = String(format: "Deserialization error: %@", error.localizedDescription)
             response.logger.error(errorMessage)
-            returnError = AzureError.general(errorMessage)
+            returnError = AzureSdkError(errorMessage)
         }
     }
 
@@ -218,7 +218,7 @@ public class ContentDecodePolicy: PipelineStage {
             jsonData = try JSONSerialization.data(withJSONObject: arrayObj, options: [])
         }
         guard let finalJsonData = jsonData else {
-            throw AzureError.sdk("Failure decoding XML.")
+            throw AzureSdkError("Failure decoding XML.")
         }
         return try JSONSerialization.jsonObject(with: finalJsonData, options: []) as AnyObject
     }

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/HeadersValidationPolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/HeadersValidationPolicy.swift
@@ -62,7 +62,7 @@ public class HeadersValidationPolicy: PipelineStage {
                     requestValue = "REDACTED"
                     responseValue = "REDACTED"
                 }
-                error = AzureError.general(
+                error = AzureSdkError(
                     "Value for header '\(key)' did not match. Expected: \(requestValue ?? "nil") Actual: \(responseValue)"
                 )
             }

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/LoggingPolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/LoggingPolicy.swift
@@ -89,7 +89,7 @@ public class LoggingPolicy: PipelineStage {
 
     public func on(error: PipelineError, completionHandler: @escaping OnErrorCompletionHandler) {
         LoggingPolicy.queue.async { self.log(response: error.pipelineResponse, withError: error.innerError) }
-        completionHandler(error, false)
+        completionHandler(error.innerError, false)
     }
 
     // MARK: Private Methods
@@ -113,7 +113,7 @@ public class LoggingPolicy: PipelineStage {
         logger.info("--> [END \(requestId)]")
     }
 
-    private func log(response: PipelineResponse, withError error: Error? = nil) {
+    private func log(response: PipelineResponse, withError error: AzureError? = nil) {
         let endTime = DispatchTime.now()
         var duration: String?
         if let startTime = response.context?.value(forKey: .requestStartTime) as? DispatchTime {

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/LoggingPolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/LoggingPolicy.swift
@@ -87,7 +87,7 @@ public class LoggingPolicy: PipelineStage {
         completionHandler(response, nil)
     }
 
-    public func on(error: PipelineError, completionHandler: @escaping OnErrorCompletionHandler) {
+    public func on(error: AzureError, completionHandler: @escaping OnErrorCompletionHandler) {
         LoggingPolicy.queue.async { self.log(response: error.pipelineResponse, withError: error.innerError) }
         completionHandler(error.innerError, false)
     }

--- a/sdk/core/AzureCore/Source/Pipeline/Transport/HTTPRequest.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Transport/HTTPRequest.swift
@@ -38,7 +38,7 @@ public class HTTPRequest: DataStringConvertible {
 
     public convenience init(method: HTTPMethod, url: String, headers: HTTPHeaders, data: Data? = nil) throws {
         guard let encodedUrl = URL(string: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)) else {
-            throw AzureError.serviceRequest("Invalid URL.")
+            throw AzureError.sdk("Invalid URL.")
         }
         try self.init(method: method, url: encodedUrl, headers: headers, data: data)
     }

--- a/sdk/core/AzureCore/Source/Pipeline/Transport/HTTPRequest.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Transport/HTTPRequest.swift
@@ -38,7 +38,7 @@ public class HTTPRequest: DataStringConvertible {
 
     public convenience init(method: HTTPMethod, url: String, headers: HTTPHeaders, data: Data? = nil) throws {
         guard let encodedUrl = URL(string: url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)) else {
-            throw AzureError.sdk("Invalid URL.")
+            throw AzureSdkError("Invalid URL.")
         }
         try self.init(method: method, url: encodedUrl, headers: headers, data: data)
     }

--- a/sdk/core/AzureCore/Source/Pipeline/Transport/URLSessionTransport.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Transport/URLSessionTransport.swift
@@ -27,10 +27,6 @@
 import Foundation
 import os
 
-public enum URLSessionTransportError: Error {
-    case invalidSession
-}
-
 public class URLSessionTransport: HTTPTransportStage {
     // MARK: Properties
 

--- a/sdk/core/AzureCore/Source/Pipeline/Transport/URLSessionTransport.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Transport/URLSessionTransport.swift
@@ -104,7 +104,7 @@ public class URLSessionTransport: HTTPTransportStage {
             )
             if let error = error {
                 completionHandler(
-                    .failure(PipelineError(fromError: error, pipelineResponse: pipelineResponse)),
+                    .failure(AzureError(fromError: error, pipelineResponse: pipelineResponse)),
                     httpResponse
                 )
             } else {

--- a/sdk/core/AzureCore/Source/Util/KeychainUtil.swift
+++ b/sdk/core/AzureCore/Source/Util/KeychainUtil.swift
@@ -31,7 +31,7 @@ public class KeychainUtil {
     internal let keychainErrorDomain = "com.azure.core"
     internal let keychainSecurityService = "com.azure.core"
 
-    private let contentError = AzureError.sdk("Invalid keychain content.")
+    private let contentError = AzureSdkError("Invalid keychain content.")
 
     // MARK: Public Methods
 
@@ -55,7 +55,7 @@ public class KeychainUtil {
         queryDictionary[kSecValueData as String] = secret
         let status = SecItemAdd(queryDictionary as CFDictionary, nil)
         guard status == errSecSuccess else {
-            throw AzureError.sdk("Failure storing keychain content.")
+            throw AzureSdkError("Failure storing keychain content.")
         }
     }
 
@@ -69,7 +69,7 @@ public class KeychainUtil {
         var data: AnyObject?
         let status = SecItemCopyMatching(queryDictionary as CFDictionary, &data)
         guard status == errSecSuccess else {
-            throw AzureError.sdk("Failure retrieving keychain secret.")
+            throw AzureSdkError("Failure retrieving keychain secret.")
         }
         if let result = data as? Data {
             return result
@@ -98,7 +98,7 @@ public class KeychainUtil {
         let queryDictionary = setupQueryDictionary(forKey: key)
         let status = SecItemDelete(queryDictionary as CFDictionary)
         guard status == errSecSuccess else {
-            throw AzureError.sdk("Failure deleting keychain secret.")
+            throw AzureSdkError("Failure deleting keychain secret.")
         }
     }
 

--- a/sdk/identity/AzureIdentity/Source/MSALCredential.swift
+++ b/sdk/identity/AzureIdentity/Source/MSALCredential.swift
@@ -133,11 +133,13 @@ import Foundation
         public func token(forScopes scopes: [String], completionHandler: @escaping TokenCompletionHandler) {
             let group = DispatchGroup()
             var accessToken: AccessToken?
-            var returnError: Error?
+            var returnError: AzureError?
             group.enter()
             if let account = account {
                 acquireTokenSilently(forAccount: account, withScopes: scopes) { result, error in
-                    returnError = error
+                    if let errorMessage = error?.localizedDescription {
+                        returnError = AzureError.system(errorMessage)
+                    }
                     if let result = result {
                         accessToken = AccessToken(
                             token: result.accessToken,
@@ -150,7 +152,9 @@ import Foundation
                 }
             } else {
                 acquireTokenInteractively(withScopes: scopes) { result, error in
-                    returnError = error
+                    if let errorMessage = error?.localizedDescription {
+                        returnError = AzureError.system(errorMessage)
+                    }
                     if let result = result {
                         self.delegate?.didCompleteMSALRequest(withResult: result)
                         accessToken = AccessToken(

--- a/sdk/storage/AzureStorageBlob/Source/Credentials/StorageCredentials.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Credentials/StorageCredentials.swift
@@ -68,14 +68,14 @@ public struct StorageSASCredential: AzureCredential {
                     Form of connection string with 'SharedAccessSignature' is expected - 'AccountKey' is not allowed.
                     You must provide a Shared Access Signature connection string.
                 """
-                error = HTTPResponseError.clientAuthentication(message)
+                error = AzureError.sdk(message)
             default:
                 continue
             }
         }
 
         if sas == nil, error == nil {
-            error = HTTPResponseError.clientAuthentication("The connection string \(connectionString) is invalid.")
+            error = AzureError.sdk("The connection string \(connectionString) is invalid.")
         }
 
         self.sasToken = sas
@@ -99,7 +99,7 @@ public struct StorageSASCredential: AzureCredential {
             sas = sasToken
             blob = "\(scheme)://\(host)/"
         } else {
-            error = HTTPResponseError.clientAuthentication("The URI \(blobSasUri) is invalid.")
+            error = AzureError.sdk("The URI \(blobSasUri) is invalid.")
         }
 
         self.sasToken = sas
@@ -168,7 +168,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
                     Form of connection string with 'AccountKey' is expected - 'SharedAccessSignature' is not allowed.
                     You must provide a storage account connection string with a shared key.
                 """
-                error = HTTPResponseError.clientAuthentication(message)
+                error = AzureError.sdk(message)
             default:
                 continue
             }
@@ -180,7 +180,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
         var table: String?
 
         if accountKey == nil, error == nil {
-            error = HTTPResponseError.clientAuthentication("The connection string \(connectionString) is invalid.")
+            error = AzureError.sdk("The connection string \(connectionString) is invalid.")
         }
 
         if let account = account {
@@ -194,7 +194,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
             file = blobEndpoint.replacingOccurrences(of: "blob.\(suffix)", with: "file.\(suffix)")
             table = blobEndpoint.replacingOccurrences(of: "blob.\(suffix)", with: "table.\(suffix)")
         } else if error == nil {
-            error = HTTPResponseError.clientAuthentication("The connection string \(connectionString) is invalid.")
+            error = AzureError.sdk("The connection string \(connectionString) is invalid.")
         }
 
         self.accountName = account
@@ -240,7 +240,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
             file = blobEndpoint.replacingOccurrences(of: "blob.\(endpointSuffix)", with: "file.\(endpointSuffix)")
             table = blobEndpoint.replacingOccurrences(of: "blob.\(endpointSuffix)", with: "table.\(endpointSuffix)")
         } else {
-            error = HTTPResponseError.clientAuthentication("The provided parameters are invalid.")
+            error = AzureError.sdk("The provided parameters are invalid.")
         }
 
         self.accountName = accountName
@@ -410,7 +410,7 @@ internal class StorageSharedKeyAuthenticationPolicy: Authenticating {
     private func canonicalized(resource: URL) throws -> String {
         guard let comps = URLComponents(url: resource, resolvingAgainstBaseURL: true),
             let accountName = comps.host?.split(separator: ".", maxSplits: 1).first else {
-            throw AzureError.general("Resource URL could not be parsed.")
+            throw AzureError.sdk("Resource URL could not be parsed.")
         }
 
         // 1. Beginning with an empty string (""), append a forward slash (/), followed by the name of the account that
@@ -436,12 +436,12 @@ internal class StorageSharedKeyAuthenticationPolicy: Authenticating {
         for name in paramNames {
             // 6. URL-decode each query parameter name and value.
             guard let decodedName = name.removingPercentEncoding else {
-                throw AzureError.general("Parameter name \(name) contains an invalid percent-encoding sequence.")
+                throw AzureError.sdk("Parameter name \(name) contains an invalid percent-encoding sequence.")
             }
 
             let decodedValues: [String] = try params[name]!.map { value in
                 guard let decoded = value.removingPercentEncoding else {
-                    throw AzureError.general("Parameter value \(value) contains an invalid percent-encoding sequence.")
+                    throw AzureError.sdk("Parameter value \(value) contains an invalid percent-encoding sequence.")
                 }
                 return decoded
             }
@@ -459,7 +459,7 @@ internal class StorageSharedKeyAuthenticationPolicy: Authenticating {
     // Generate the signature for the string to sign.
     private func signature(forString signingString: String, withKey accessKey: String) throws -> String {
         guard let keyData = Data(base64Encoded: accessKey) else {
-            throw AzureError.general("Unable to decode access key.")
+            throw AzureError.sdk("Unable to decode access key.")
         }
         let hmac = signingString.hmac(algorithm: .sha256, key: keyData)
         return hmac.base64EncodedString()

--- a/sdk/storage/AzureStorageBlob/Source/Credentials/StorageCredentials.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Credentials/StorageCredentials.swift
@@ -68,14 +68,14 @@ public struct StorageSASCredential: AzureCredential {
                     Form of connection string with 'SharedAccessSignature' is expected - 'AccountKey' is not allowed.
                     You must provide a Shared Access Signature connection string.
                 """
-                error = AzureError.sdk(message)
+                error = AzureSdkError(message)
             default:
                 continue
             }
         }
 
         if sas == nil, error == nil {
-            error = AzureError.sdk("The connection string \(connectionString) is invalid.")
+            error = AzureSdkError("The connection string \(connectionString) is invalid.")
         }
 
         self.sasToken = sas
@@ -99,7 +99,7 @@ public struct StorageSASCredential: AzureCredential {
             sas = sasToken
             blob = "\(scheme)://\(host)/"
         } else {
-            error = AzureError.sdk("The URI \(blobSasUri) is invalid.")
+            error = AzureSdkError("The URI \(blobSasUri) is invalid.")
         }
 
         self.sasToken = sas
@@ -168,7 +168,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
                     Form of connection string with 'AccountKey' is expected - 'SharedAccessSignature' is not allowed.
                     You must provide a storage account connection string with a shared key.
                 """
-                error = AzureError.sdk(message)
+                error = AzureSdkError(message)
             default:
                 continue
             }
@@ -180,7 +180,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
         var table: String?
 
         if accountKey == nil, error == nil {
-            error = AzureError.sdk("The connection string \(connectionString) is invalid.")
+            error = AzureSdkError("The connection string \(connectionString) is invalid.")
         }
 
         if let account = account {
@@ -194,7 +194,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
             file = blobEndpoint.replacingOccurrences(of: "blob.\(suffix)", with: "file.\(suffix)")
             table = blobEndpoint.replacingOccurrences(of: "blob.\(suffix)", with: "table.\(suffix)")
         } else if error == nil {
-            error = AzureError.sdk("The connection string \(connectionString) is invalid.")
+            error = AzureSdkError("The connection string \(connectionString) is invalid.")
         }
 
         self.accountName = account
@@ -240,7 +240,7 @@ public struct StorageSharedKeyCredential: AzureCredential {
             file = blobEndpoint.replacingOccurrences(of: "blob.\(endpointSuffix)", with: "file.\(endpointSuffix)")
             table = blobEndpoint.replacingOccurrences(of: "blob.\(endpointSuffix)", with: "table.\(endpointSuffix)")
         } else {
-            error = AzureError.sdk("The provided parameters are invalid.")
+            error = AzureSdkError("The provided parameters are invalid.")
         }
 
         self.accountName = accountName
@@ -410,7 +410,7 @@ internal class StorageSharedKeyAuthenticationPolicy: Authenticating {
     private func canonicalized(resource: URL) throws -> String {
         guard let comps = URLComponents(url: resource, resolvingAgainstBaseURL: true),
             let accountName = comps.host?.split(separator: ".", maxSplits: 1).first else {
-            throw AzureError.sdk("Resource URL could not be parsed.")
+            throw AzureSdkError("Resource URL could not be parsed.")
         }
 
         // 1. Beginning with an empty string (""), append a forward slash (/), followed by the name of the account that
@@ -436,12 +436,12 @@ internal class StorageSharedKeyAuthenticationPolicy: Authenticating {
         for name in paramNames {
             // 6. URL-decode each query parameter name and value.
             guard let decodedName = name.removingPercentEncoding else {
-                throw AzureError.sdk("Parameter name \(name) contains an invalid percent-encoding sequence.")
+                throw AzureSdkError("Parameter name \(name) contains an invalid percent-encoding sequence.")
             }
 
             let decodedValues: [String] = try params[name]!.map { value in
                 guard let decoded = value.removingPercentEncoding else {
-                    throw AzureError.sdk("Parameter value \(value) contains an invalid percent-encoding sequence.")
+                    throw AzureSdkError("Parameter value \(value) contains an invalid percent-encoding sequence.")
                 }
                 return decoded
             }
@@ -459,7 +459,7 @@ internal class StorageSharedKeyAuthenticationPolicy: Authenticating {
     // Generate the signature for the string to sign.
     private func signature(forString signingString: String, withKey accessKey: String) throws -> String {
         guard let keyData = Data(base64Encoded: accessKey) else {
-            throw AzureError.sdk("Unable to decode access key.")
+            throw AzureSdkError("Unable to decode access key.")
         }
         let hmac = signingString.hmac(algorithm: .sha256, key: keyData)
         return hmac.base64EncodedString()

--- a/sdk/storage/AzureStorageBlob/Source/Models/BlobLookupList.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Models/BlobLookupList.swift
@@ -44,7 +44,7 @@ internal struct BlobLookupList: XMLModel {
 
     public func asXmlString(encoding: String.Encoding = .utf8) throws -> String {
         guard encoding == .utf8 else {
-            throw AzureError.sdk("Unsupported encoding: \(encoding.description)")
+            throw AzureSdkError("Unsupported encoding: \(encoding.description)")
         }
         var lines = ["<?xml version=\"1.0\" encoding=\"utf-8\"?>", "<BlockList>"]
         // This will only serialize the "latest" list. This is a carryover from Python

--- a/sdk/storage/AzureStorageBlob/Source/Models/BlobLookupList.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Models/BlobLookupList.swift
@@ -44,7 +44,7 @@ internal struct BlobLookupList: XMLModel {
 
     public func asXmlString(encoding: String.Encoding = .utf8) throws -> String {
         guard encoding == .utf8 else {
-            throw AzureError.serviceRequest("Unsupported encoding: \(encoding.description)")
+            throw AzureError.sdk("Unsupported encoding: \(encoding.description)")
         }
         var lines = ["<?xml version=\"1.0\" encoding=\"utf-8\"?>", "<BlockList>"]
         // This will only serialize the "latest" list. This is a carryover from Python

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -174,10 +174,10 @@ public final class StorageBlobClient: PipelineClient {
     ) throws {
         try credential.validate()
         guard let blobEndpoint = credential.blobEndpoint else {
-            throw AzureError.sdk("Invalid connection string. No blob endpoint specified.")
+            throw AzureSdkError("Invalid connection string. No blob endpoint specified.")
         }
         guard let baseUrl = URL(string: blobEndpoint) else {
-            throw AzureError.sdk("Unable to resolve account URL from credential.")
+            throw AzureSdkError("Unable to resolve account URL from credential.")
         }
         let authPolicy = StorageSASAuthenticationPolicy(credential: credential)
         try self.init(baseUrl: baseUrl, authPolicy: authPolicy, withRestorationId: restorationId, withOptions: options)
@@ -204,7 +204,7 @@ public final class StorageBlobClient: PipelineClient {
     ) throws {
         try credential.validate()
         guard let baseUrl = URL(string: credential.blobEndpoint) else {
-            throw AzureError.sdk("Unable to resolve account URL from credential.")
+            throw AzureSdkError("Unable to resolve account URL from credential.")
         }
         let authPolicy = StorageSharedKeyAuthenticationPolicy(credential: credential)
         try self.init(baseUrl: baseUrl, authPolicy: authPolicy, withRestorationId: restorationId, withOptions: options)
@@ -250,7 +250,7 @@ public final class StorageBlobClient: PipelineClient {
             return
         }
 
-        throw AzureError.sdk("The connection string \(connectionString) is invalid.")
+        throw AzureSdkError("The connection string \(connectionString) is invalid.")
     }
 
     /// Create a Storage blob data client.
@@ -346,7 +346,7 @@ public final class StorageBlobClient: PipelineClient {
             switch result {
             case let .success(data):
                 guard let data = data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
+                    let noDataError = AzureSdkError("Response data expected but not found.")
                     DispatchQueue.main.async {
                         completionHandler(.failure(noDataError), httpResponse)
                     }
@@ -440,7 +440,7 @@ public final class StorageBlobClient: PipelineClient {
             switch result {
             case let .success(data):
                 guard let data = data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
+                    let noDataError = AzureSdkError("Response data expected but not found.")
 
                     DispatchQueue.main.async {
                         completionHandler(.failure(noDataError), httpResponse)

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -174,10 +174,10 @@ public final class StorageBlobClient: PipelineClient {
     ) throws {
         try credential.validate()
         guard let blobEndpoint = credential.blobEndpoint else {
-            throw AzureError.serviceRequest("Invalid connection string. No blob endpoint specified.")
+            throw AzureError.sdk("Invalid connection string. No blob endpoint specified.")
         }
         guard let baseUrl = URL(string: blobEndpoint) else {
-            throw AzureError.fileSystem("Unable to resolve account URL from credential.")
+            throw AzureError.sdk("Unable to resolve account URL from credential.")
         }
         let authPolicy = StorageSASAuthenticationPolicy(credential: credential)
         try self.init(baseUrl: baseUrl, authPolicy: authPolicy, withRestorationId: restorationId, withOptions: options)
@@ -204,7 +204,7 @@ public final class StorageBlobClient: PipelineClient {
     ) throws {
         try credential.validate()
         guard let baseUrl = URL(string: credential.blobEndpoint) else {
-            throw AzureError.fileSystem("Unable to resolve account URL from credential.")
+            throw AzureError.sdk("Unable to resolve account URL from credential.")
         }
         let authPolicy = StorageSharedKeyAuthenticationPolicy(credential: credential)
         try self.init(baseUrl: baseUrl, authPolicy: authPolicy, withRestorationId: restorationId, withOptions: options)
@@ -250,7 +250,7 @@ public final class StorageBlobClient: PipelineClient {
             return
         }
 
-        throw HTTPResponseError.clientAuthentication("The connection string \(connectionString) is invalid.")
+        throw AzureError.sdk("The connection string \(connectionString) is invalid.")
     }
 
     /// Create a Storage blob data client.
@@ -346,7 +346,7 @@ public final class StorageBlobClient: PipelineClient {
             switch result {
             case let .success(data):
                 guard let data = data else {
-                    let noDataError = HTTPResponseError.decode("Response data expected but not found.")
+                    let noDataError = AzureError.sdk("Response data expected but not found.")
                     DispatchQueue.main.async {
                         completionHandler(.failure(noDataError), httpResponse)
                     }
@@ -366,7 +366,7 @@ public final class StorageBlobClient: PipelineClient {
                     }
                 } catch {
                     DispatchQueue.main.async {
-                        completionHandler(.failure(error), httpResponse)
+                        completionHandler(.failure(error.toAzureError), httpResponse)
                     }
                 }
             case let .failure(error):
@@ -440,7 +440,7 @@ public final class StorageBlobClient: PipelineClient {
             switch result {
             case let .success(data):
                 guard let data = data else {
-                    let noDataError = HTTPResponseError.decode("Response data expected but not found.")
+                    let noDataError = AzureError.sdk("Response data expected but not found.")
 
                     DispatchQueue.main.async {
                         completionHandler(.failure(noDataError), httpResponse)
@@ -461,7 +461,7 @@ public final class StorageBlobClient: PipelineClient {
                     }
                 } catch {
                     DispatchQueue.main.async {
-                        completionHandler(.failure(error), httpResponse)
+                        completionHandler(.failure(error.toAzureError), httpResponse)
                     }
                 }
             case let .failure(error):

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -102,20 +102,20 @@ internal class ChunkDownloader {
             case let .success(data):
                 guard let data = data else {
                     completionHandler(
-                        .failure(HTTPResponseError.decode("Blob unexpectedly contained no data.")),
+                        .failure(AzureError.sdk("Blob unexpectedly contained no data.")),
                         httpResponse
                     )
                     return
                 }
                 guard let headers = httpResponse?.headers else {
-                    completionHandler(.failure(HTTPResponseError.general("No response headers found.")), httpResponse)
+                    completionHandler(.failure(AzureError.sdk("No response headers found.")), httpResponse)
                     return
                 }
                 if let contentMD5 = headers[.contentMD5] {
                     let dataHash = data.hash(algorithm: .md5).base64EncodedString()
                     guard contentMD5 == dataHash else {
-                        let error = HTTPResponseError
-                            .resourceModified("Block MD5 \(dataHash) did not match \(contentMD5).")
+                        let error = AzureError
+                            .sdk("Block MD5 \(dataHash) did not match \(contentMD5).")
                         completionHandler(.failure(error), httpResponse)
                         return
                     }
@@ -124,8 +124,8 @@ internal class ChunkDownloader {
                     // TODO: Implement CRC64. Currently no iOS library supports this!
                     let dataHash = ""
                     guard contentCRC64 == dataHash else {
-                        let error = HTTPResponseError
-                            .resourceModified("Block CRC64 \(dataHash) did not match \(contentCRC64).")
+                        let error = AzureError
+                            .sdk("Block CRC64 \(dataHash) did not match \(contentCRC64).")
                         completionHandler(.failure(error), httpResponse)
                         return
                     }
@@ -145,7 +145,7 @@ internal class ChunkDownloader {
 
                     completionHandler(.success(decryptedData), httpResponse)
                 } catch {
-                    completionHandler(.failure(error), httpResponse)
+                    completionHandler(.failure(error.toAzureError), httpResponse)
                 }
             }
         }
@@ -308,7 +308,7 @@ internal class BlobStreamDownloader: BlobDownloader {
         options: DownloadBlobOptions? = nil
     ) throws {
         guard let downloadDestination = destination.resolvedUrl else {
-            throw AzureError.fileSystem("Unable to determine download destination: \(destination)")
+            throw AzureError.sdk("Unable to determine download destination: \(destination)")
         }
 
         self.downloadDestination = downloadDestination
@@ -383,7 +383,7 @@ internal class BlobStreamDownloader: BlobDownloader {
             switch result {
             case .success:
                 guard let responseHeaders = httpResponse?.headers else {
-                    completionHandler(.failure(HTTPResponseError.general("No response headers found.")), httpResponse)
+                    completionHandler(.failure(AzureError.sdk("No response headers found.")), httpResponse)
                     return
                 }
                 let blobProperties = BlobProperties(from: responseHeaders)
@@ -415,7 +415,7 @@ internal class BlobStreamDownloader: BlobDownloader {
                 // Parse the total file size and adjust the download size if ranges
                 // were specified
                 guard let responseHeaders = httpResponse?.headers else {
-                    completionHandler(.failure(HTTPResponseError.general("No response headers found.")), httpResponse)
+                    completionHandler(.failure(AzureError.sdk("No response headers found.")), httpResponse)
                     return
                 }
                 let contentRange = responseHeaders[.contentRange]
@@ -423,7 +423,7 @@ internal class BlobStreamDownloader: BlobDownloader {
 
                 // Only block blobs are currently supported
                 guard blobProperties.blobType == BlobType.block else {
-                    let error = AzureError.general("Page and Append blobs are not currently supported by this library.")
+                    let error = AzureError.sdk("Page and Append blobs are not currently supported by this library.")
                     completionHandler(.failure(error), httpResponse)
                     return
                 }
@@ -464,7 +464,7 @@ internal class BlobStreamDownloader: BlobDownloader {
                     }
                     completionHandler(.success(data), httpResponse)
                 } catch {
-                    completionHandler(.failure(error), httpResponse)
+                    completionHandler(.failure(error.toAzureError), httpResponse)
                 }
             case let .failure(error):
                 completionHandler(.failure(error), httpResponse)
@@ -500,7 +500,7 @@ internal class BlobStreamDownloader: BlobDownloader {
 
     /// Parses the blob length from the content range header: bytes 1-3/65537
     private func parseLength(fromContentRange contentRange: String?) throws -> Int {
-        let error = HTTPResponseError.decode("Unable to parse content range: \(contentRange ?? "nil")")
+        let error = AzureError.sdk("Unable to parse content range: \(contentRange ?? "nil")")
         guard let contentRange = contentRange else { throw error }
         // First, split in space and take the second half: "1-3/65537"
         guard let byteString = contentRange.split(separator: " ", maxSplits: 1).last else { throw error }

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamDownloader.swift
@@ -102,13 +102,13 @@ internal class ChunkDownloader {
             case let .success(data):
                 guard let data = data else {
                     completionHandler(
-                        .failure(AzureError.sdk("Blob unexpectedly contained no data.")),
+                        .failure(AzureSdkError("Blob unexpectedly contained no data.")),
                         httpResponse
                     )
                     return
                 }
                 guard let headers = httpResponse?.headers else {
-                    completionHandler(.failure(AzureError.sdk("No response headers found.")), httpResponse)
+                    completionHandler(.failure(AzureSdkError("No response headers found.")), httpResponse)
                     return
                 }
                 if let contentMD5 = headers[.contentMD5] {
@@ -308,7 +308,7 @@ internal class BlobStreamDownloader: BlobDownloader {
         options: DownloadBlobOptions? = nil
     ) throws {
         guard let downloadDestination = destination.resolvedUrl else {
-            throw AzureError.sdk("Unable to determine download destination: \(destination)")
+            throw AzureSdkError("Unable to determine download destination: \(destination)")
         }
 
         self.downloadDestination = downloadDestination
@@ -383,7 +383,7 @@ internal class BlobStreamDownloader: BlobDownloader {
             switch result {
             case .success:
                 guard let responseHeaders = httpResponse?.headers else {
-                    completionHandler(.failure(AzureError.sdk("No response headers found.")), httpResponse)
+                    completionHandler(.failure(AzureSdkError("No response headers found.")), httpResponse)
                     return
                 }
                 let blobProperties = BlobProperties(from: responseHeaders)
@@ -415,7 +415,7 @@ internal class BlobStreamDownloader: BlobDownloader {
                 // Parse the total file size and adjust the download size if ranges
                 // were specified
                 guard let responseHeaders = httpResponse?.headers else {
-                    completionHandler(.failure(AzureError.sdk("No response headers found.")), httpResponse)
+                    completionHandler(.failure(AzureSdkError("No response headers found.")), httpResponse)
                     return
                 }
                 let contentRange = responseHeaders[.contentRange]
@@ -423,7 +423,7 @@ internal class BlobStreamDownloader: BlobDownloader {
 
                 // Only block blobs are currently supported
                 guard blobProperties.blobType == BlobType.block else {
-                    let error = AzureError.sdk("Page and Append blobs are not currently supported by this library.")
+                    let error = AzureSdkError("Page and Append blobs are not currently supported by this library.")
                     completionHandler(.failure(error), httpResponse)
                     return
                 }
@@ -500,7 +500,7 @@ internal class BlobStreamDownloader: BlobDownloader {
 
     /// Parses the blob length from the content range header: bytes 1-3/65537
     private func parseLength(fromContentRange contentRange: String?) throws -> Int {
-        let error = AzureError.sdk("Unable to parse content range: \(contentRange ?? "nil")")
+        let error = AzureSdkError("Unable to parse content range: \(contentRange ?? "nil")")
         guard let contentRange = contentRange else { throw error }
         // First, split in space and take the second half: "1-3/65537"
         guard let byteString = contentRange.split(separator: " ", maxSplits: 1).last else { throw error }

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamUploader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamUploader.swift
@@ -106,7 +106,7 @@ internal class ChunkUploader {
             buffer.append(tempData)
         } catch {
             let request = try? HTTPRequest(method: .put, url: uploadDestination, headers: HTTPHeaders())
-            completionHandler(.failure(error), HTTPResponse(request: request, statusCode: nil))
+            completionHandler(.failure(error.toAzureError), HTTPResponse(request: request, statusCode: nil))
             return
         }
 
@@ -274,12 +274,12 @@ internal class BlobStreamUploader: BlobUploader {
         options: UploadBlobOptions? = nil
     ) throws {
         guard let uploadSource = source.resolvedUrl else {
-            throw AzureError.fileSystem("Unable to determine upload source: \(source)")
+            throw AzureError.sdk("Unable to determine upload source: \(source)")
         }
 
         let attributes = try FileManager.default.attributesOfItem(atPath: uploadSource.path)
         guard let fileSize = attributes[FileAttributeKey.size] as? Int else {
-            throw AzureError.fileSystem("Unable to determine file size: \(uploadSource.path)")
+            throw AzureError.sdk("Unable to determine file size: \(uploadSource.path)")
         }
 
         self.uploadSource = uploadSource
@@ -382,7 +382,7 @@ internal class BlobStreamUploader: BlobUploader {
                 completionHandler(.failure(error), httpResponse)
             case .success:
                 guard let responseHeaders = httpResponse?.headers else {
-                    let error = HTTPResponseError.general("No response received.")
+                    let error = AzureError.sdk("No response received.")
                     completionHandler(.failure(error), httpResponse)
                     return
                 }
@@ -529,7 +529,7 @@ internal class BlobStreamUploader: BlobUploader {
 
     /// Parses the blob length from the content range header: bytes 1-3/65537
     private func parseLength(fromContentRange contentRange: String?) throws -> Int {
-        let error = HTTPResponseError.decode("Unable to parse content range: \(contentRange ?? "nil")")
+        let error = AzureError.sdk("Unable to parse content range: \(contentRange ?? "nil")")
         guard let contentRange = contentRange else { throw error }
         // split on slash and take the second half: "65537"
         guard let lengthString = contentRange.split(separator: "/", maxSplits: 1).last else { throw error }

--- a/sdk/storage/AzureStorageBlob/Source/StorageStreamUploader.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageStreamUploader.swift
@@ -274,12 +274,12 @@ internal class BlobStreamUploader: BlobUploader {
         options: UploadBlobOptions? = nil
     ) throws {
         guard let uploadSource = source.resolvedUrl else {
-            throw AzureError.sdk("Unable to determine upload source: \(source)")
+            throw AzureSdkError("Unable to determine upload source: \(source)")
         }
 
         let attributes = try FileManager.default.attributesOfItem(atPath: uploadSource.path)
         guard let fileSize = attributes[FileAttributeKey.size] as? Int else {
-            throw AzureError.sdk("Unable to determine file size: \(uploadSource.path)")
+            throw AzureSdkError("Unable to determine file size: \(uploadSource.path)")
         }
 
         self.uploadSource = uploadSource
@@ -382,7 +382,7 @@ internal class BlobStreamUploader: BlobUploader {
                 completionHandler(.failure(error), httpResponse)
             case .success:
                 guard let responseHeaders = httpResponse?.headers else {
-                    let error = AzureError.sdk("No response received.")
+                    let error = AzureSdkError("No response received.")
                     completionHandler(.failure(error), httpResponse)
                     return
                 }
@@ -529,7 +529,7 @@ internal class BlobStreamUploader: BlobUploader {
 
     /// Parses the blob length from the content range header: bytes 1-3/65537
     private func parseLength(fromContentRange contentRange: String?) throws -> Int {
-        let error = AzureError.sdk("Unable to parse content range: \(contentRange ?? "nil")")
+        let error = AzureSdkError("Unable to parse content range: \(contentRange ?? "nil")")
         guard let contentRange = contentRange else { throw error }
         // split on slash and take the second half: "65537"
         guard let lengthString = contentRange.split(separator: "/", maxSplits: 1).last else { throw error }

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -151,7 +151,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
     func register(client: StorageBlobClient) throws {
         let restorationId = client.restorationId
         guard blobClient(forRestorationId: restorationId) == nil else {
-            throw AzureError.sdk(
+            throw AzureSdkError(
                 """
                     A client with restoration ID \(restorationId) already exists. Please ensure that each client has a \
                     unique restoration ID.
@@ -537,7 +537,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
             """
             assertionFailure(errorMessage)
 
-            transfer.error = AzureError.sdk(errorMessage)
+            transfer.error = AzureSdkError(errorMessage)
             transfer.state = .failed
             return
         }

--- a/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
+++ b/sdk/storage/AzureStorageBlob/Source/Transport/URLSessionTransferManager.swift
@@ -151,7 +151,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
     func register(client: StorageBlobClient) throws {
         let restorationId = client.restorationId
         guard blobClient(forRestorationId: restorationId) == nil else {
-            throw AzureError.general(
+            throw AzureError.sdk(
                 """
                     A client with restoration ID \(restorationId) already exists. Please ensure that each client has a \
                     unique restoration ID.
@@ -537,7 +537,7 @@ internal final class URLSessionTransferManager: NSObject, TransferManager, URLSe
             """
             assertionFailure(errorMessage)
 
-            transfer.error = AzureError.general(errorMessage)
+            transfer.error = AzureError.sdk(errorMessage)
             transfer.state = .failed
             return
         }


### PR DESCRIPTION
Closes #292.

Consolidates to a single `AzureError` type that has three values: 
- `sdk` - any errors generated and thrown by the SDK.
- `system` - any errors passed from the service through the SDK.
- `service` - any error generated from the system or OS that is then passed through the SDK. 

The distinction will hopefully allow us to better triage bug reports by focusing on those errors and error messages that come directly from the SDK.