### PR TITLE
Remove azure-sdk-build-tools repo resource

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -1,9 +1,5 @@
 resources:
   repositories:
-  - repository: azure-sdk-build-tools
-    type: git
-    name: internal/azure-sdk-build-tools
-    ref: refs/heads/feature/engsys-ios-barebones
   - repository: azure-sdk-tools
     type: github
     name: Azure/azure-sdk-tools


### PR DESCRIPTION
Remove reference to `azure-sdk-build-tools` as it's no longer needed.