### PR TITLE
Remove AzureIdentity from Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,6 @@ let package = Package(
     ],
     products: [
         .library(name: "AzureCore", targets: ["AzureCore"]),
-        .library(name: "AzureIdentity", targets: ["AzureIdentity"]),
         .library(name: "AzureStorageBlob", targets: ["AzureStorageBlob"])
     ],
     dependencies: [],
@@ -46,12 +45,6 @@ let package = Package(
             name: "AzureCore",
             dependencies: [],
             path: "sdk/core/AzureCore",
-            sources: ["Source"]
-        ),
-        .target(
-            name: "AzureIdentity",
-            dependencies: ["AzureCore"],
-            path: "sdk/identity/AzureIdentity",
             sources: ["Source"]
         ),
         .target(
@@ -65,12 +58,6 @@ let package = Package(
             name: "AzureCoreTests",
             dependencies: ["AzureCore"],
             path: "sdk/core/AzureCore",
-            sources: ["Tests"]
-        ),
-        .testTarget(
-            name: "AzureIdentityTests",
-            dependencies: ["AzureIdentity"],
-            path: "sdk/identity/AzureIdentity",
             sources: ["Tests"]
         ),
         .testTarget(

--- a/sdk/identity/AzureIdentity/Source/MSALCredential.swift
+++ b/sdk/identity/AzureIdentity/Source/MSALCredential.swift
@@ -25,191 +25,187 @@
 // --------------------------------------------------------------------------
 import AzureCore
 import Foundation
-#if canImport(MSAL)
-    import MSAL
-#endif
+import MSAL
 
-#if canImport(MSAL)
-    public typealias MSALResultCompletionHandler = (MSALResult?, Error?) -> Void
+public typealias MSALResultCompletionHandler = (MSALResult?, Error?) -> Void
 
-    /// Delegate protocol for view controllers to hook into the MSAL interactive flow.
-    public protocol MSALInteractiveDelegate: AnyObject {
-        // MARK: Required Methods
+/// Delegate protocol for view controllers to hook into the MSAL interactive flow.
+public protocol MSALInteractiveDelegate: AnyObject {
+    // MARK: Required Methods
 
-        func parentForWebView() -> UIViewController
-        func didCompleteMSALRequest(withResult result: MSALResult)
+    func parentForWebView() -> UIViewController
+    func didCompleteMSALRequest(withResult result: MSALResult)
+}
+
+public extension MSALInteractiveDelegate where Self: UIViewController {
+    func parentForWebView() -> UIViewController {
+        return self
     }
 
-    public extension MSALInteractiveDelegate where Self: UIViewController {
-        func parentForWebView() -> UIViewController {
-            return self
-        }
+    func didCompleteMSALRequest(withResult _: MSALResult) {}
+}
 
-        func didCompleteMSALRequest(withResult _: MSALResult) {}
+/// An MSAL credential object.
+public struct MSALCredential: TokenCredential {
+    // MARK: Properties
+
+    private let tenant: String?
+    private let clientId: String?
+    private let application: MSALPublicClientApplication?
+    private let account: MSALAccount?
+    private let error: Error?
+
+    private weak var delegate: MSALInteractiveDelegate? {
+        return ApplicationUtil.currentViewController(forParent: nil) as? MSALInteractiveDelegate
     }
 
-    /// An MSAL credential object.
-    public struct MSALCredential: TokenCredential {
-        // MARK: Properties
+    // MARK: Initializers
 
-        private let tenant: String?
-        private let clientId: String?
-        private let application: MSALPublicClientApplication?
-        private let account: MSALAccount?
-        private let error: Error?
-
-        private weak var delegate: MSALInteractiveDelegate? {
-            return ApplicationUtil.currentViewController(forParent: nil) as? MSALInteractiveDelegate
+    /// Create an OAuth credential.
+    /// - Parameters:
+    ///   - tenant: Tenant ID (a GUID) for the AAD instance.
+    ///   - clientId: The service principal client or application ID (a GUID).
+    ///   - authority: An authority URI for the application.
+    ///   - redirectUri: An optional redirect URI for the application.
+    ///   - account: Initial value of the `MSALAccount` object, if known.
+    public init(
+        tenant: String,
+        clientId: String,
+        authority: URL,
+        redirectUri: String? = nil,
+        account: MSALAccount? = nil
+    ) {
+        var application: MSALPublicClientApplication?
+        var validationError: Error?
+        do {
+            let aadAuthority = try MSALAADAuthority(url: authority)
+            let config = MSALPublicClientApplicationConfig(
+                clientId: clientId,
+                redirectUri: redirectUri,
+                authority: aadAuthority
+            )
+            application = try MSALPublicClientApplication(configuration: config)
+        } catch {
+            validationError = error
         }
 
-        // MARK: Initializers
+        self.tenant = tenant
+        self.clientId = clientId
+        self.application = application
+        self.account = account
+        self.error = validationError
+    }
 
-        /// Create an OAuth credential.
-        /// - Parameters:
-        ///   - tenant: Tenant ID (a GUID) for the AAD instance.
-        ///   - clientId: The service principal client or application ID (a GUID).
-        ///   - authority: An authority URI for the application.
-        ///   - redirectUri: An optional redirect URI for the application.
-        ///   - account: Initial value of the `MSALAccount` object, if known.
-        public init(
-            tenant: String,
-            clientId: String,
-            authority: URL,
-            redirectUri: String? = nil,
-            account: MSALAccount? = nil
-        ) {
-            var application: MSALPublicClientApplication?
-            var validationError: Error?
-            do {
-                let aadAuthority = try MSALAADAuthority(url: authority)
-                let config = MSALPublicClientApplicationConfig(
-                    clientId: clientId,
-                    redirectUri: redirectUri,
-                    authority: aadAuthority
-                )
-                application = try MSALPublicClientApplication(configuration: config)
-            } catch {
-                validationError = error
-            }
+    /// Create an OAuth credential.
+    /// - Parameters:
+    ///   - tenant: Tenant ID (a GUID) for the AAD instance.
+    ///   - clientId: The service principal client or application ID (a GUID).
+    ///   - application: An `MSALPublicClientApplication` object.
+    ///   - account: Initial value of the `MSALAccount` object, if known.
+    public init(
+        tenant: String,
+        clientId: String,
+        application: MSALPublicClientApplication,
+        account: MSALAccount? = nil
+    ) {
+        self.tenant = tenant
+        self.clientId = clientId
+        self.application = application
+        self.account = account
+        self.error = nil
+    }
 
-            self.tenant = tenant
-            self.clientId = clientId
-            self.application = application
-            self.account = account
-            self.error = validationError
+    // MARK: Public Methods
+
+    public func validate() throws {
+        if let error = error {
+            throw error
         }
+    }
 
-        /// Create an OAuth credential.
-        /// - Parameters:
-        ///   - tenant: Tenant ID (a GUID) for the AAD instance.
-        ///   - clientId: The service principal client or application ID (a GUID).
-        ///   - application: An `MSALPublicClientApplication` object.
-        ///   - account: Initial value of the `MSALAccount` object, if known.
-        public init(
-            tenant: String,
-            clientId: String,
-            application: MSALPublicClientApplication,
-            account: MSALAccount? = nil
-        ) {
-            self.tenant = tenant
-            self.clientId = clientId
-            self.application = application
-            self.account = account
-            self.error = nil
-        }
-
-        // MARK: Public Methods
-
-        public func validate() throws {
-            if let error = error {
-                throw error
-            }
-        }
-
-        /// Retrieve a token for the provided scope.
-        /// - Parameters:
-        ///   - scopes: A list of a scope strings for which to retrieve the token.
-        ///   - completionHandler: A completion handler which forwards the access token.
-        public func token(forScopes scopes: [String], completionHandler: @escaping TokenCompletionHandler) {
-            let group = DispatchGroup()
-            var accessToken: AccessToken?
-            var returnError: AzureError?
-            group.enter()
-            if let account = account {
-                acquireTokenSilently(forAccount: account, withScopes: scopes) { result, error in
-                    if let error = error {
-                        returnError = AzureError.sdk("MSAL error.", error)
-                    }
-                    if let result = result {
-                        accessToken = AccessToken(
-                            token: result.accessToken,
-                            expiresOn: result.expiresOn
-                        )
-                    } else {
-                        accessToken = nil
-                    }
-                    group.leave()
-                }
-            } else {
-                acquireTokenInteractively(withScopes: scopes) { result, error in
-                    if let err = error {
-                        returnError = AzureError.sdk("MSAL failure.", err)
-                    }
-                    if let result = result {
-                        self.delegate?.didCompleteMSALRequest(withResult: result)
-                        accessToken = AccessToken(
-                            token: result.accessToken,
-                            expiresOn: result.expiresOn
-                        )
-                    } else {
-                        accessToken = nil
-                    }
-                    group.leave()
-                }
-            }
-            group.notify(queue: DispatchQueue.main) {
-                completionHandler(accessToken, returnError)
-            }
-        }
-
-        // MARK: Internal Methods
-
-        internal func acquireTokenInteractively(
-            withScopes scopes: [String],
-            completionHandler: @escaping MSALResultCompletionHandler
-        ) {
-            guard let parent = delegate?.parentForWebView(), let application = application else { return }
-            let webViewParameters = MSALWebviewParameters(parentViewController: parent)
-            let parameters = MSALInteractiveTokenParameters(scopes: scopes, webviewParameters: webViewParameters)
-            application.acquireToken(with: parameters) { result, error in
-                completionHandler(result, error)
-            }
-        }
-
-        internal func acquireTokenSilently(
-            forAccount account: MSALAccount,
-            withScopes scopes: [String],
-            completionHandler: @escaping MSALResultCompletionHandler
-        ) {
-            guard let application = application else { return }
-            let parameters = MSALSilentTokenParameters(scopes: scopes, account: account)
-            application.acquireTokenSilent(with: parameters) { result, error in
+    /// Retrieve a token for the provided scope.
+    /// - Parameters:
+    ///   - scopes: A list of a scope strings for which to retrieve the token.
+    ///   - completionHandler: A completion handler which forwards the access token.
+    public func token(forScopes scopes: [String], completionHandler: @escaping TokenCompletionHandler) {
+        let group = DispatchGroup()
+        var accessToken: AccessToken?
+        var returnError: AzureError?
+        group.enter()
+        if let account = account {
+            acquireTokenSilently(forAccount: account, withScopes: scopes) { result, error in
                 if let error = error {
-                    let nsError = error as NSError
+                    returnError = AzureError.sdk("MSAL error.", error)
+                }
+                if let result = result {
+                    accessToken = AccessToken(
+                        token: result.accessToken,
+                        expiresOn: result.expiresOn
+                    )
+                } else {
+                    accessToken = nil
+                }
+                group.leave()
+            }
+        } else {
+            acquireTokenInteractively(withScopes: scopes) { result, error in
+                if let err = error {
+                    returnError = AzureError.sdk("MSAL failure.", err)
+                }
+                if let result = result {
+                    self.delegate?.didCompleteMSALRequest(withResult: result)
+                    accessToken = AccessToken(
+                        token: result.accessToken,
+                        expiresOn: result.expiresOn
+                    )
+                } else {
+                    accessToken = nil
+                }
+                group.leave()
+            }
+        }
+        group.notify(queue: DispatchQueue.main) {
+            completionHandler(accessToken, returnError)
+        }
+    }
 
-                    // interactionRequired means we need to ask the user to sign-in. This usually happens
-                    // when the user's Refresh Token is expired or if the user has changed their password
-                    // among other possible reasons.
-                    if nsError.domain == MSALErrorDomain {
-                        if nsError.code == MSALError.interactionRequired.rawValue {
-                            self.acquireTokenInteractively(withScopes: scopes) { result, error in
-                                completionHandler(result, error)
-                            }
+    // MARK: Internal Methods
+
+    internal func acquireTokenInteractively(
+        withScopes scopes: [String],
+        completionHandler: @escaping MSALResultCompletionHandler
+    ) {
+        guard let parent = delegate?.parentForWebView(), let application = application else { return }
+        let webViewParameters = MSALWebviewParameters(parentViewController: parent)
+        let parameters = MSALInteractiveTokenParameters(scopes: scopes, webviewParameters: webViewParameters)
+        application.acquireToken(with: parameters) { result, error in
+            completionHandler(result, error)
+        }
+    }
+
+    internal func acquireTokenSilently(
+        forAccount account: MSALAccount,
+        withScopes scopes: [String],
+        completionHandler: @escaping MSALResultCompletionHandler
+    ) {
+        guard let application = application else { return }
+        let parameters = MSALSilentTokenParameters(scopes: scopes, account: account)
+        application.acquireTokenSilent(with: parameters) { result, error in
+            if let error = error {
+                let nsError = error as NSError
+
+                // interactionRequired means we need to ask the user to sign-in. This usually happens
+                // when the user's Refresh Token is expired or if the user has changed their password
+                // among other possible reasons.
+                if nsError.domain == MSALErrorDomain {
+                    if nsError.code == MSALError.interactionRequired.rawValue {
+                        self.acquireTokenInteractively(withScopes: scopes) { result, error in
+                            completionHandler(result, error)
                         }
                     }
                 }
-                completionHandler(result, error)
             }
+            completionHandler(result, error)
         }
     }
-#endif
+}

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -25,7 +25,7 @@
 // --------------------------------------------------------------------------
 
 import AzureCore
-#if canImport(AzureIdentity) && canImport(MSAL)
+#if canImport(AzureIdentity)
     import AzureIdentity
 #endif
 import CoreData
@@ -113,7 +113,7 @@ public final class StorageBlobClient: PipelineClient {
         try StorageBlobClient.manager.register(client: self)
     }
 
-    #if canImport(AzureIdentity) && canImport(MSAL)
+    #if canImport(AzureIdentity)
         /// Create a Storage blob data client.
         /// - Parameters:
         ///   - credential: A `MSALCredential` object used to retrieve authentication tokens.


### PR DESCRIPTION
This PR removes AzureIdentity from the Package.swift file. This is because we won't initially have the MSAL dependency hooked up in the shipping package so we don't need it (although we can still use it for development purposes and building out the demo app).