### PR TITLE
ContentDecodePolicy should pass through data to client

### DIFF
--- a/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
@@ -231,7 +231,7 @@ public class ContentDecodePolicy: PipelineStage {
     internal func deserialize(from response: PipelineResponse, contentType: String) throws -> AnyObject? {
         guard let data = response.httpResponse?.data else { return nil }
         if jsonRegex.hasMatch(in: contentType) {
-            return try JSONSerialization.jsonObject(with: data, options: []) as AnyObject
+            return data as AnyObject
         } else if contentType.contains("xml") {
             xmlParser.xmlMap = response.value(forKey: .xmlMap) as? XMLMap
             xmlParser.logger = response.logger


### PR DESCRIPTION
Fixes #444.

Previously, we would find content type JSON and do a round-trip deserialized/serialize loop to validate that the data was a valid JSON **object**. However, content type `application/json` is any valid JSON, not just JSON objects, which will cause this check to fail for cases within the autorest testserver since there are bodies that are valid JSON but not JSON objects. 