### PR TITLE
Call JSONSerialization.data in deserialize() method when is JSON

### DIFF
--- a/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/ContentDecodePolicy.swift
@@ -194,8 +194,7 @@ public class ContentDecodePolicy: PipelineStage {
         else { return }
         contentType = contentType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         do {
-            if let deserializedJson = try deserialize(from: returnResponse, contentType: contentType) {
-                let deserializedData = try JSONSerialization.data(withJSONObject: deserializedJson, options: [])
+            if let deserializedData = try deserialize(from: returnResponse, contentType: contentType) {
                 returnResponse.add(value: deserializedData as AnyObject, forKey: .deserializedData)
             }
         } catch {
@@ -235,7 +234,8 @@ public class ContentDecodePolicy: PipelineStage {
         } else if contentType.contains("xml") {
             xmlParser.xmlMap = response.value(forKey: .xmlMap) as? XMLMap
             xmlParser.logger = response.logger
-            return try parse(xml: data)
+            let jsonData = try parse(xml: data)
+            return try JSONSerialization.data(withJSONObject: jsonData, options: []) as AnyObject
         }
         return nil
     }


### PR DESCRIPTION
* deserialize() can return non JSON format data. And the caller of deserialize() (ContentDecodePolicy on() method) will always call JSONSerialization.data() with the return value from deserialize(). And this will reult in 'Deserialization error." and the failure callback of PipelineClient will get invokded.
* We should only call  JSONSerialization.data() when the data is in JSON format. So we move the call of ' JSONSerialization.data()' inside 'deserialize()'. And we only call 'JSONSerialization.data()' when the xml data is converted into JSON format.