### PR TITLE
[CommunicationAccessToken] Communication created version of access token 

### DIFF
--- a/sdk/communication/AzureCommunication/AzureCommunication.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunication/AzureCommunication.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1DE4DB7724C0FE8300631921 /* AutoRefreshUserCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE4DB7624C0FE8300631921 /* AutoRefreshUserCredential.swift */; };
 		1DE4DB7924C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE4DB7824C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift */; };
 		7AAE2D17251444B600C9F897 /* CommunicationAuthenticationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAE2D16251444B600C9F897 /* CommunicationAuthenticationPolicy.swift */; };
+		8856CEAC253A376D00044559 /* CommunicationAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */; };
 		F11E5CC824B77F8900AA3A58 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A3A5ED62316DB8F00473FDA /* AzureCore.framework */; };
 		F183A5EB24AF9D9000F0E0D5 /* CommunicationTokenCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F183A5EA24AF9D9000F0E0D5 /* CommunicationTokenCredential.swift */; };
 		F183A5FA24AFB37900F0E0D5 /* StaticUserCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F183A5F924AFB37900F0E0D5 /* StaticUserCredential.swift */; };
@@ -63,6 +64,7 @@
 		1DE4DB7624C0FE8300631921 /* AutoRefreshUserCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoRefreshUserCredential.swift; sourceTree = "<group>"; };
 		1DE4DB7824C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeRefreshableAccessTokenCache.swift; sourceTree = "<group>"; };
 		7AAE2D16251444B600C9F897 /* CommunicationAuthenticationPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommunicationAuthenticationPolicy.swift; sourceTree = "<group>"; };
+		8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationAccessToken.swift; sourceTree = "<group>"; };
 		F183A5EA24AF9D9000F0E0D5 /* CommunicationTokenCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationTokenCredential.swift; sourceTree = "<group>"; };
 		F183A5F924AFB37900F0E0D5 /* StaticUserCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticUserCredential.swift; sourceTree = "<group>"; };
 		F183A5FB24AFEF1400F0E0D5 /* CommunicationUserCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationUserCredential.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 		1D2E7F6E24E4536500447964 /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
+				8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */,
 				F183A5EA24AF9D9000F0E0D5 /* CommunicationTokenCredential.swift */,
 				F183A5F924AFB37900F0E0D5 /* StaticUserCredential.swift */,
 				F183A5FB24AFEF1400F0E0D5 /* CommunicationUserCredential.swift */,
@@ -287,6 +290,7 @@
 			files = (
 				F183A5EB24AF9D9000F0E0D5 /* CommunicationTokenCredential.swift in Sources */,
 				1D2E7F7024E4589100447964 /* Identifiers.swift in Sources */,
+				8856CEAC253A376D00044559 /* CommunicationAccessToken.swift in Sources */,
 				1DE4DB7924C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift in Sources */,
 				1DE4DB7724C0FE8300631921 /* AutoRefreshUserCredential.swift in Sources */,
 				F183A5FC24AFEF1400F0E0D5 /* CommunicationUserCredential.swift in Sources */,

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
@@ -25,8 +25,13 @@
 // --------------------------------------------------------------------------
 
 import Foundation
-
-public struct CommunicationAccessToken {
+// This is class
+@objcMembers public class CommunicationAccessToken: NSObject {
     let token: String
     let expiresOn: Date
+    
+    public init(token: String, expiresOn: Date) {
+        self.token = token
+        self.expiresOn = expiresOn
+    }
 }

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
@@ -24,37 +24,9 @@
 //
 // --------------------------------------------------------------------------
 
-#if canImport(AzureCore)
-import AzureCore
-#endif
 import Foundation
-/**
- The Azure Communication Services User token credential. 
- */
-internal class StaticUserCredential: CommunicationTokenCredential {
-    private let accessToken: CommunicationAccessToken
 
-    /**
-     Creates a static `CommunicationUserCredential` object from the provided token.
-        
-     - Parameter token: The static token to use for authenticating all requests.
-     
-     - Throws: `AzureError` if the provided token is not a valid token.
-     
-     - SeeAlso: ` CommunicationUserCredential.init(...)`
-     */
-    public init(token: String) throws {
-        self.accessToken = try JwtTokenParser.createAccessToken(token)
-    }
-
-    /**
-     Retrieve an access token from the credential.
-     
-     - Parameter completionHandler: Closure that accepts an optional `AccessToken` or optional `Error` as parameters.
-     `AccessToken` returns a token and an expiry date if applicable. `Error` returns `nil` if the current token can be returned.
-
-     */
-    public func token(completionHandler: AccessTokenRefreshOnCompletion) {
-        completionHandler(accessToken, nil)
-    }
+public struct CommunicationAccessToken {
+    let token: String
+    let expiresOn: Date
 }

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
@@ -25,7 +25,7 @@
 // --------------------------------------------------------------------------
 
 import Foundation
-// This is class
+
 @objcMembers public class CommunicationAccessToken: NSObject {
     let token: String
     let expiresOn: Date

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationUserCredential.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationUserCredential.swift
@@ -29,7 +29,7 @@ import AzureCore
 #endif
 import Foundation
 
-public typealias AccessTokenRefreshOnCompletion = (AccessToken?, Error?) -> Void
+public typealias AccessTokenRefreshOnCompletion = (CommunicationAccessToken?, Error?) -> Void
 public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
 
 /**

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationUserCredential.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationUserCredential.swift
@@ -35,7 +35,7 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
 /**
  The Azure Communication Services User token credential. This class is used to cache/refresh the access token required by Azure Communication Services.
 */
-public class CommunicationUserCredential: NSObject {
+@objcMembers public class CommunicationUserCredential: NSObject {
     private let userTokenCredential: CommunicationTokenCredential
     
     /**

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationUserCredential.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationUserCredential.swift
@@ -35,7 +35,7 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
 /**
  The Azure Communication Services User token credential. This class is used to cache/refresh the access token required by Azure Communication Services.
 */
-@objcMembers public class CommunicationUserCredential: NSObject {
+public class CommunicationUserCredential: NSObject {
     private let userTokenCredential: CommunicationTokenCredential
     
     /**

--- a/sdk/communication/AzureCommunication/Source/Authentication/JwtTokenParser.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/JwtTokenParser.swift
@@ -43,9 +43,9 @@ struct JwtTokenParser {
      
      - Returns: A new `AccessToken` instance
      */
-    static func createAccessToken(_ token: String) throws -> AccessToken {
+    static func createAccessToken(_ token: String) throws -> CommunicationAccessToken {
         let payload = try decodeJwtPayload(token)
-        return AccessToken(token: token, expiresOn: Date(timeIntervalSince1970: TimeInterval(payload.exp)))
+        return CommunicationAccessToken(token: token, expiresOn: Date(timeIntervalSince1970: TimeInterval(payload.exp)))
     }
     
     /**

--- a/sdk/communication/AzureCommunication/Source/Authentication/ThreadSafeRefreshableAccessTokenCache.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/ThreadSafeRefreshableAccessTokenCache.swift
@@ -30,7 +30,7 @@ import AzureCore
 import Foundation
 
 internal class ThreadSafeRefreshableAccessTokenCache {
-    private var currentToken: AccessToken {
+    private var currentToken: CommunicationAccessToken {
         didSet {
             maybeScheduleRefresh()
         }
@@ -51,14 +51,14 @@ internal class ThreadSafeRefreshableAccessTokenCache {
     public convenience init(refreshProactively: Bool, tokenRefresher: @escaping TokenRefreshAction) {
         self.init(
             refreshProactively: refreshProactively,
-            initialValue: AccessToken(token: "", expiresOn: Date()),
+            initialValue: CommunicationAccessToken(token: "", expiresOn: Date()),
             tokenRefresher: tokenRefresher
         )
     }
 
     public init(
         refreshProactively: Bool,
-        initialValue: AccessToken,
+        initialValue: CommunicationAccessToken,
         tokenRefresher: @escaping TokenRefreshAction
     ) {
         self.scheduleProactivelyRefreshing = refreshProactively

--- a/sdk/communication/AzureCommunication/Tests/CommunicationUserCredentialTests.swift
+++ b/sdk/communication/AzureCommunication/Tests/CommunicationUserCredentialTests.swift
@@ -83,7 +83,7 @@ class CommunicationUserCredentialTests: XCTestCase {
 
     func test_DecodesToken() throws {
         let userCredential = try CommunicationUserCredential(token: sampleToken)
-        userCredential.token { (accessToken: AccessToken?, error: Error?) in
+        userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
             XCTAssertNil(error)
             XCTAssertEqual(accessToken?.token, self.sampleToken)
             XCTAssertEqual(accessToken?.expiresOn.timeIntervalSince1970, self.sampleTokenExpiry)
@@ -108,7 +108,7 @@ class CommunicationUserCredentialTests: XCTestCase {
         )
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
-            userCredential.token { (accessToken: AccessToken?, error: Error?) in
+            userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(accessToken)
                 XCTAssertNil(error)
                 XCTAssertEqual(accessToken?.token, self.sampleToken)
@@ -131,7 +131,7 @@ class CommunicationUserCredentialTests: XCTestCase {
         )
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
-            userCredential.token { (accessToken: AccessToken?, error: Error?) in
+            userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error.debugDescription.contains("Error while fetching token"), true)
                 XCTAssertNil(accessToken)
@@ -163,11 +163,11 @@ class CommunicationUserCredentialTests: XCTestCase {
             )
 
             DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
-                userCredential.token { (accessToken: AccessToken?, _: Error?) in
+                userCredential.token { (accessToken: CommunicationAccessToken?, _: Error?) in
                     XCTAssertNotNil(accessToken)
                     XCTAssertEqual(accessToken?.token, self.sampleToken)
 
-                    userCredential.token { (accessToken: AccessToken?, _: Error?) in
+                    userCredential.token { (accessToken: CommunicationAccessToken?, _: Error?) in
                         XCTAssertNotNil(accessToken)
                         XCTAssertEqual(accessToken?.token, self.sampleToken)
                         XCTAssertEqual(self.fetchTokenCallCount, 1)
@@ -198,7 +198,7 @@ class CommunicationUserCredentialTests: XCTestCase {
         )
 
         DispatchQueue.global(qos: .utility).async {
-            userCredential.token { (accessToken: AccessToken?, error: Error?) in
+            userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(accessToken)
                 XCTAssertNil(error)
                 XCTAssertEqual(accessToken?.token, expectedToken)
@@ -224,7 +224,7 @@ class CommunicationUserCredentialTests: XCTestCase {
         )
 
         DispatchQueue.global(qos: .utility).async {
-            userCredential.token { (accessToken: AccessToken?, error: Error?) in
+            userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(accessToken)
                 XCTAssertNil(error)
                 XCTAssertEqual(accessToken?.token, expectedToken)

--- a/sdk/core/AzureCore/Source/Pipeline/Policies/AuthenticationPolicy.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Policies/AuthenticationPolicy.swift
@@ -27,7 +27,7 @@ import Foundation
 
 public typealias TokenCompletionHandler = (AccessToken?, AzureError?) -> Void
 
-@objcMembers public class AccessToken: NSObject {
+public struct AccessToken {
     // MARK: Properties
 
     public let token: String


### PR DESCRIPTION
Currently, AzureCommunication depends on AzureCore's AccessToken. Chat is built in obj-c so requires an obj-c members. For chat to use AzureCommunication properly we need to create our own obj-c class access token. At the same time the Access token in Core can be changed back to a pure struct. 