### PR TITLE
Make CommunicationAccessToken members public

### DIFF
--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationAccessToken.swift
@@ -27,8 +27,8 @@
 import Foundation
 
 @objcMembers public class CommunicationAccessToken: NSObject {
-    let token: String
-    let expiresOn: Date
+    public let token: String
+    public let expiresOn: Date
     
     public init(token: String, expiresOn: Date) {
         self.token = token


### PR DESCRIPTION
token and expiresToken needs to be public so that it can be accessed from ObjC code