### PR TITLE
Remove test artifacts from AzureCore public interface

### DIFF
--- a/sdk/core/AzureCore/AzureCore.xcodeproj/project.pbxproj
+++ b/sdk/core/AzureCore/AzureCore.xcodeproj/project.pbxproj
@@ -11,7 +11,9 @@
 		0A18D7B523A95FEC008959E6 /* Copyable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A18D7B423A95FEC008959E6 /* Copyable.swift */; };
 		0A22B09024CF490C00EC018E /* TransportOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A22B08F24CF490C00EC018E /* TransportOptions.swift */; };
 		0A22B09224CF611F00EC018E /* TelemetryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A22B09124CF611F00EC018E /* TelemetryOptions.swift */; };
-		0A22B09424CF84F300EC018E /* TestClientOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A22B09324CF84F300EC018E /* TestClientOptions.swift */; };
+		0A348C3F255071E800C63618 /* TestClientOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A22B09324CF84F300EC018E /* TestClientOptions.swift */; };
+		0A348C42255071ED00C63618 /* TestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FD2A254B2564002CBFD8 /* TestClient.swift */; };
+		0A348C44255071F000C63618 /* TestCallOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FD27254B2521002CBFD8 /* TestCallOptions.swift */; };
 		0A3A5D9B2315CEB600473FDA /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3A5D902315CEB600473FDA /* HTTPRequest.swift */; };
 		0A3A5D9C2315CEB600473FDA /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3A5D912315CEB600473FDA /* HTTPResponse.swift */; };
 		0A3A5D9D2315CEB600473FDA /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3A5D922315CEB600473FDA /* HTTPMethod.swift */; };
@@ -33,8 +35,6 @@
 		0A532ACF2417E71100C4C8BA /* XMLMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A532ACE2417E71100C4C8BA /* XMLMap.swift */; };
 		0A532AD12417E73C00C4C8BA /* XMLTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A532AD02417E73C00C4C8BA /* XMLTree.swift */; };
 		0A55FC3C2548B63D002CBFD8 /* RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FC3B2548B63D002CBFD8 /* RetryPolicy.swift */; };
-		0A55FD28254B2521002CBFD8 /* TestCallOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FD27254B2521002CBFD8 /* TestCallOptions.swift */; };
-		0A55FD2B254B2565002CBFD8 /* TestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FD2A254B2564002CBFD8 /* TestClient.swift */; };
 		0A55FD2E254B25BD002CBFD8 /* TestPolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FD2D254B25BD002CBFD8 /* TestPolicies.swift */; };
 		0A55FD35254B322B002CBFD8 /* PipelineContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A55FD30254B31AB002CBFD8 /* PipelineContextTests.swift */; };
 		0A6864B8233EAC76004B7E17 /* ContentDecodePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6864B7233EAC76004B7E17 /* ContentDecodePolicy.swift */; };
@@ -648,14 +648,11 @@
 				0A3A5F3C2318904F00473FDA /* PipelineResponse.swift in Sources */,
 				0A532AD12417E73C00C4C8BA /* XMLTree.swift in Sources */,
 				0A22B09024CF490C00EC018E /* TransportOptions.swift in Sources */,
-				0A22B09424CF84F300EC018E /* TestClientOptions.swift in Sources */,
 				0A55FD2E254B25BD002CBFD8 /* TestPolicies.swift in Sources */,
 				0A3A5F032316DF6600473FDA /* CryptoUtil.swift in Sources */,
-				0A55FD28254B2521002CBFD8 /* TestCallOptions.swift in Sources */,
 				7AA5366923C0340C00A65A96 /* BundleInfoProvider.swift in Sources */,
 				0AC0AA83234D017F00F05073 /* AzureCodable.swift in Sources */,
 				0A3A5F1C2316EBC600473FDA /* HeadersPolicy.swift in Sources */,
-				0A55FD2B254B2565002CBFD8 /* TestClient.swift in Sources */,
 				0A0DD9AF24AE7D5800D2E884 /* CancellationToken.swift in Sources */,
 				0A3A5F222316FAF000473FDA /* UserAgentPolicy.swift in Sources */,
 				7AA5366B23C0341B00A65A96 /* PlatformInfoProvider.swift in Sources */,
@@ -680,6 +677,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A348C44255071F000C63618 /* TestCallOptions.swift in Sources */,
 				0AE3263D249A7F9A00C85EAA /* NormalizeETagPolicyTests.swift in Sources */,
 				7A1A917123D13F0300B0B3D2 /* ProviderStubs.swift in Sources */,
 				7A968D0323E0FC6400E0F054 /* LoggerStubs.swift in Sources */,
@@ -691,12 +689,14 @@
 				7AFA4D6223D14F01001A3BF4 /* LoggingPolicyTests.swift in Sources */,
 				0AFEC35D23C8FC3A0065D588 /* CollectionsTests.swift in Sources */,
 				0AFEC36223C8FC490065D588 /* UtilTests.swift in Sources */,
+				0A348C42255071ED00C63618 /* TestClient.swift in Sources */,
 				0AFEC36123C8FC460065D588 /* UserAgentPolicyTests.swift in Sources */,
 				0AFEC35E23C8FC3D0065D588 /* HTTPRequestTests.swift in Sources */,
 				0AFEC35F23C8FC400065D588 /* PipelineRequestTests.swift in Sources */,
 				7A1A916F23D13E5D00B0B3D2 /* PipelineStubs.swift in Sources */,
 				0AFEC36023C8FC430065D588 /* PipelineTests.swift in Sources */,
 				0AFEC36323C8FC4C0065D588 /* XMLModelTests.swift in Sources */,
+				0A348C3F255071E800C63618 /* TestClientOptions.swift in Sources */,
 				0AD6351F23F46CC4000D67F6 /* ReachabilityManagerTests.swift in Sources */,
 				7A1A916C23D13D5700B0B3D2 /* RequestIdPolicyTests.swift in Sources */,
 			);

--- a/sdk/core/AzureCore/Tests/Stubs/TestCallOptions.swift
+++ b/sdk/core/AzureCore/Tests/Stubs/TestCallOptions.swift
@@ -24,9 +24,10 @@
 //
 // --------------------------------------------------------------------------
 
+import AzureCore
 import Foundation
 
-public struct TestCallOptions: RequestOptions {
+struct TestCallOptions: RequestOptions {
     public var clientRequestId: String?
     public var cancellationToken: CancellationToken?
     public var dispatchQueue: DispatchQueue?

--- a/sdk/core/AzureCore/Tests/Stubs/TestClient.swift
+++ b/sdk/core/AzureCore/Tests/Stubs/TestClient.swift
@@ -24,10 +24,11 @@
 //
 // --------------------------------------------------------------------------
 
+import AzureCore
 import Foundation
 
 // swiftlint:disable force_try
-public class TestClient: PipelineClient {
+class TestClient: PipelineClient {
     // MARK: Properties
 
     public let options: TestClientOptions

--- a/sdk/core/AzureCore/Tests/Stubs/TestClientOptions.swift
+++ b/sdk/core/AzureCore/Tests/Stubs/TestClientOptions.swift
@@ -24,9 +24,10 @@
 //
 // --------------------------------------------------------------------------
 
+import AzureCore
 import Foundation
 
-public struct TestClientOptions: ClientOptions {
+struct TestClientOptions: ClientOptions {
     public var apiVersion = "TestAPI"
     public var logger = ClientLoggers.default(tag: "AzureTest")
     public var telemetryOptions = TelemetryOptions()


### PR DESCRIPTION
These mistakenly appear in the AzureCore public interface and don't need to.