### PR TITLE
[Communication] - Auth - Introducing CommunicationTokenRefreshOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 - Azure Communication Common Library
   - Added a new communication identifier `MicrosoftTeamsUserIdentifier`, used to represent a Microsoft Teams user.
+  - Introduced a new `CommunicationTokenRefreshOptions`. A new object that encompasses properties to define communication token refresh options.
 
 ### Breaking Changes
 - Azure Communication Common Library
@@ -12,7 +13,8 @@
   - The protocol `CommunicationTokenCredential` has likewise been renamed to `CommunicationTokenCredentialProviding`.
   - All types that conform to the `CommunicationIdentifier` protocol now use the suffix `Identifier`. For example, the
     `PhoneNumber` type used to represent a phone number identifier is now named `PhoneNumberIdentifier`.
-
+  - Updated  `CommunicationTokenCredential` init method to take in the new  `CommunicationTokenRefreshOptions` .
+  
 ## 1.0.0-beta.6 (2020-11-23)
 
 ### Key Bug Fixes

--- a/sdk/communication/AzureCommunication/AzureCommunication.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunication/AzureCommunication.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1DE4DB7724C0FE8300631921 /* AutoRefreshTokenCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE4DB7624C0FE8300631921 /* AutoRefreshTokenCredential.swift */; };
 		1DE4DB7924C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE4DB7824C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift */; };
 		7AAE2D17251444B600C9F897 /* CommunicationAuthenticationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAE2D16251444B600C9F897 /* CommunicationAuthenticationPolicy.swift */; };
+		882F28D425A632CA009689E3 /* CommunicationTokenRefreshOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882F28D325A632CA009689E3 /* CommunicationTokenRefreshOptions.swift */; };
 		8856CEAC253A376D00044559 /* CommunicationAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */; };
 		8856CEE5253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8856CEE4253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m */; };
 		88CC8C35254750260028977C /* ObjCCommunicationTokenCredentialAsyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88CC8C34254750260028977C /* ObjCCommunicationTokenCredentialAsyncTests.m */; };
@@ -67,6 +68,7 @@
 		1DE4DB7624C0FE8300631921 /* AutoRefreshTokenCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoRefreshTokenCredential.swift; sourceTree = "<group>"; };
 		1DE4DB7824C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeRefreshableAccessTokenCache.swift; sourceTree = "<group>"; };
 		7AAE2D16251444B600C9F897 /* CommunicationAuthenticationPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommunicationAuthenticationPolicy.swift; sourceTree = "<group>"; };
+		882F28D325A632CA009689E3 /* CommunicationTokenRefreshOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationTokenRefreshOptions.swift; sourceTree = "<group>"; };
 		8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationAccessToken.swift; sourceTree = "<group>"; };
 		8856CEE3253E3AEF00044559 /* AzureCommunicationTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AzureCommunicationTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		8856CEE4253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCCommunicationTokenCredentialTests.m; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				1DE4DB7624C0FE8300631921 /* AutoRefreshTokenCredential.swift */,
 				1DE4DB7824C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift */,
 				7AAE2D16251444B600C9F897 /* CommunicationAuthenticationPolicy.swift */,
+				882F28D325A632CA009689E3 /* CommunicationTokenRefreshOptions.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -304,6 +307,7 @@
 				8856CEAC253A376D00044559 /* CommunicationAccessToken.swift in Sources */,
 				1DE4DB7924C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift in Sources */,
 				1DE4DB7724C0FE8300631921 /* AutoRefreshTokenCredential.swift in Sources */,
+				882F28D425A632CA009689E3 /* CommunicationTokenRefreshOptions.swift in Sources */,
 				F183A5FC24AFEF1400F0E0D5 /* CommunicationTokenCredential.swift in Sources */,
 				7AAE2D17251444B600C9F897 /* CommunicationAuthenticationPolicy.swift in Sources */,
 				F183A5FE24AFF1B100F0E0D5 /* JwtTokenParser.swift in Sources */,

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenCredential.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenCredential.swift
@@ -63,18 +63,13 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
         - tokenRefresher: Closure to call when a new token value is needed.
      - Throws: `AzureError` if the provided token is not a valid user token.
      */
-    public init(
-        initialToken: String? = nil,
-        refreshProactively: Bool = false,
-        tokenRefresher: @escaping (@escaping TokenRefreshOnCompletion) -> Void
-    ) throws {
+    public init(with option: CommunicationTokenRefreshOptions) throws {
         self.userTokenCredential = try AutoRefreshTokenCredential(
-            tokenRefresher: tokenRefresher,
-            refreshProactively: refreshProactively,
-            initialToken: initialToken
+            tokenRefresher: option.tokenRefresher,
+            refreshProactively: option.refreshProactively,
+            initialToken: option.initialToken
         )
     }
-
     /**
      Retrieve an access token from the credential.
      - Parameter completionHandler: Closure that accepts an optional `AccessToken` or optional `Error` as parameters.
@@ -82,5 +77,21 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
      */
     public func token(completionHandler: @escaping CommunicationTokenCompletionHandler) {
         userTokenCredential.token(completionHandler: completionHandler)
+    }
+}
+
+@objcMembers public class CommunicationTokenRefreshOptions: NSObject {
+    var initialToken: String?
+    var refreshProactively: Bool
+    var tokenRefresher: (@escaping TokenRefreshOnCompletion) -> Void
+    
+    public init(
+        initialToken: String? = nil,
+        refreshProactively: Bool = false,
+        tokenRefresher: @escaping (@escaping TokenRefreshOnCompletion) -> Void
+    ) {
+        self.initialToken = initialToken
+        self.refreshProactively = refreshProactively
+        self.tokenRefresher = tokenRefresher
     }
 }

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenCredential.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenCredential.swift
@@ -49,7 +49,7 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
         self.userTokenCredential = try StaticTokenCredential(token: token)
     }
     /**
-     Creates a CommunicationUserCredential that automatically refreshes the token.
+     Creates a CommunicationTokenCredential that automatically refreshes the token.
      - Parameters:
         - option: Options for how the token will be refreshed
      - Throws: `AzureError` if the provided token is not a valid user token.
@@ -68,35 +68,5 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
      */
     public func token(completionHandler: @escaping CommunicationTokenCompletionHandler) {
         userTokenCredential.token(completionHandler: completionHandler)
-    }
-}
-/**
- The Communication Token Refresh Options. Used to initialize a `CommunicationUserCredential`
- - SeeAlso: ` CommunicationUserCredential.init(...)`
-*/
-@objcMembers public class CommunicationTokenRefreshOptions: NSObject {
-    var initialToken: String?
-    var refreshProactively: Bool
-    var tokenRefresher: (@escaping TokenRefreshOnCompletion) -> Void
-    /**
-     Initializes a new instance of `CommunicationTokenRefreshOptions`
-     The cached token is updated if `token(completionHandler: )` is called and if the difference between the current time
-     and token expiry time is less than 120s.
-     If `refreshProactively` parameter  is `true`:
-        - The cached token will be updated in the background when the difference between the current time and token expiry time is less than 600s.
-        - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
-     - Parameters:
-        - initialToken: The initial value of the token.
-        - refreshProactively: Whether the token should be proactively refreshed in the background.
-        - tokenRefresher: Closure to call when a new token value is needed.
-     */
-    public init(
-        initialToken: String? = nil,
-        refreshProactively: Bool = false,
-        tokenRefresher: @escaping (@escaping TokenRefreshOnCompletion) -> Void
-    ) {
-        self.initialToken = initialToken
-        self.refreshProactively = refreshProactively
-        self.tokenRefresher = tokenRefresher
     }
 }

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenCredential.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenCredential.swift
@@ -49,18 +49,9 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
         self.userTokenCredential = try StaticTokenCredential(token: token)
     }
     /**
-     Creates a CommunicationTokenCredential that automatically refreshes the token.
-     The cached token is updated if `token(completionHandler: )` is called and if the difference between the current time
-     and token expiry time is less than 120s.
-     If `refreshProactively` parameter  is `true`:
-        - The cached token will be updated in the background when the difference between the current time
-            and token expiry time is less than 600s.
-        - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
-        
+     Creates a CommunicationUserCredential that automatically refreshes the token.
      - Parameters:
-        - initialToken: The initial value of the token.
-        - refreshProactively: Whether the token should be proactively refreshed in the background.
-        - tokenRefresher: Closure to call when a new token value is needed.
+        - option: Options for how the token will be refreshed
      - Throws: `AzureError` if the provided token is not a valid user token.
      */
     public init(with option: CommunicationTokenRefreshOptions) throws {
@@ -79,12 +70,26 @@ public typealias TokenRefreshOnCompletion = (String?, Error?) -> Void
         userTokenCredential.token(completionHandler: completionHandler)
     }
 }
-
+/**
+ The Communication Token Refresh Options. Used to initialize a `CommunicationUserCredential`
+ - SeeAlso: ` CommunicationUserCredential.init(...)`
+*/
 @objcMembers public class CommunicationTokenRefreshOptions: NSObject {
     var initialToken: String?
     var refreshProactively: Bool
     var tokenRefresher: (@escaping TokenRefreshOnCompletion) -> Void
-    
+    /**
+     Initializes a new instance of `CommunicationTokenRefreshOptions`
+     The cached token is updated if `token(completionHandler: )` is called and if the difference between the current time
+     and token expiry time is less than 120s.
+     If `refreshProactively` parameter  is `true`:
+        - The cached token will be updated in the background when the difference between the current time and token expiry time is less than 600s.
+        - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
+     - Parameters:
+        - initialToken: The initial value of the token.
+        - refreshProactively: Whether the token should be proactively refreshed in the background.
+        - tokenRefresher: Closure to call when a new token value is needed.
+     */
     public init(
         initialToken: String? = nil,
         refreshProactively: Bool = false,

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
@@ -26,6 +26,7 @@
 
 import Foundation
 
+public typealias TokenRefresherClosure = (@escaping TokenRefreshOnCompletion) -> Void
 /**
  The Communication Token Refresh Options. Used to initialize a `CommunicationUserCredential`
  - SeeAlso: ` CommunicationUserCredential.init(...)`
@@ -33,7 +34,7 @@ import Foundation
 @objcMembers public class CommunicationTokenRefreshOptions: NSObject {
     var initialToken: String?
     var refreshProactively: Bool
-    var tokenRefresher: (@escaping TokenRefreshOnCompletion) -> Void
+    var tokenRefresher: TokenRefresherClosure
     /**
      Initializes a new instance of `CommunicationTokenRefreshOptions`
      The cached token is updated if `token(completionHandler: )` is called and if the difference between the current time
@@ -49,7 +50,7 @@ import Foundation
     public init(
         initialToken: String? = nil,
         refreshProactively: Bool = false,
-        tokenRefresher: @escaping (@escaping TokenRefreshOnCompletion) -> Void
+        tokenRefresher: @escaping TokenRefresherClosure
     ) {
         self.initialToken = initialToken
         self.refreshProactively = refreshProactively

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
@@ -1,0 +1,58 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+/**
+ The Communication Token Refresh Options. Used to initialize a `CommunicationUserCredential`
+ - SeeAlso: ` CommunicationUserCredential.init(...)`
+*/
+@objcMembers public class CommunicationTokenRefreshOptions: NSObject {
+    var initialToken: String?
+    var refreshProactively: Bool
+    var tokenRefresher: (@escaping TokenRefreshOnCompletion) -> Void
+    /**
+     Initializes a new instance of `CommunicationTokenRefreshOptions`
+     The cached token is updated if `token(completionHandler: )` is called and if the difference between the current time
+     and token expiry time is less than 120s.
+     If `refreshProactively` parameter  is `true`:
+        - The cached token will be updated in the background when the difference between the current time and token expiry time is less than 600s.
+        - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
+     - Parameters:
+        - initialToken: The initial value of the token.
+        - refreshProactively: Whether the token should be proactively refreshed in the background.
+        - tokenRefresher: Closure to call when a new token value is needed.
+     */
+    public init(
+        initialToken: String? = nil,
+        refreshProactively: Bool = false,
+        tokenRefresher: @escaping (@escaping TokenRefreshOnCompletion) -> Void
+    ) {
+        self.initialToken = initialToken
+        self.refreshProactively = refreshProactively
+        self.tokenRefresher = tokenRefresher
+    }
+}

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
@@ -39,12 +39,13 @@ import Foundation
      The cached token is updated if `token(completionHandler: )` is called and if the difference between the current time
      and token expiry time is less than 120s.
      If `refreshProactively` parameter  is `true`:
-        - The cached token will be updated in the background when the difference between the current time and token expiry time is less than 600s.
-        - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
+     - The cached token will be updated in the background when the difference between the current time and token expiry time is less than 600s.
+     - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
+     
      - Parameters:
-        - initialToken: The initial value of the token.
-        - refreshProactively: Whether the token should be proactively refreshed in the background.
-        - tokenRefresher: Closure to call when a new token value is needed.
+     - initialToken: The initial value of the token.
+     - refreshProactively: Whether the token should be proactively refreshed in the background.
+     - tokenRefresher: Closure to call when a new token value is needed.
      */
     public init(
         initialToken: String? = nil,

--- a/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
+++ b/sdk/communication/AzureCommunication/Source/Authentication/CommunicationTokenRefreshOptions.swift
@@ -41,7 +41,6 @@ import Foundation
      If `refreshProactively` parameter  is `true`:
      - The cached token will be updated in the background when the difference between the current time and token expiry time is less than 600s.
      - The cached token will be updated immediately when the constructor is invoked and `initialToken` is expired
-     
      - Parameters:
      - initialToken: The initial value of the token.
      - refreshProactively: Whether the token should be proactively refreshed in the background.

--- a/sdk/communication/AzureCommunication/Tests/CommunicationTokenCredentialTests.swift
+++ b/sdk/communication/AzureCommunication/Tests/CommunicationTokenCredentialTests.swift
@@ -101,12 +101,12 @@ class CommunicationTokenCredentialTests: XCTestCase {
     func test_RefreshTokenProactively_TokenAlreadyExpired() throws {
         let expectation = XCTestExpectation()
 
-        let option = CommunicationTokenRefreshOptions(
+        let tokenRefreshOptions = CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: true,
             tokenRefresher: fetchTokenSync)
         
-        let userCredential = try CommunicationTokenCredential(with: option)
+        let userCredential = try CommunicationTokenCredential(with: tokenRefreshOptions)
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
@@ -125,13 +125,13 @@ class CommunicationTokenCredentialTests: XCTestCase {
     func test_RefreshTokenProactively_FetchTokenReturnsError() throws {
         let expectation = XCTestExpectation()
 
-        let option =  CommunicationTokenRefreshOptions(
+        let tokenRefreshOptions =  CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: true,
             tokenRefresher: fetchTokenSyncWithError
         )
         
-        let userCredential = try CommunicationTokenCredential(with: option)
+        let userCredential = try CommunicationTokenCredential(with: tokenRefreshOptions)
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
@@ -159,13 +159,13 @@ class CommunicationTokenCredentialTests: XCTestCase {
 
             let expiringToken = generateTokenValidForMinutes(minutes)
 
-            let option = CommunicationTokenRefreshOptions(
+            let tokenRefreshOptions = CommunicationTokenRefreshOptions(
                 initialToken: expiringToken,
                 refreshProactively: true,
                 tokenRefresher: fetchTokenSync
             )
 
-            let userCredential = try CommunicationTokenCredential(with: option)
+            let userCredential = try CommunicationTokenCredential(with: tokenRefreshOptions)
             
             DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
                 userCredential.token { (accessToken: CommunicationAccessToken?, _: Error?) in
@@ -196,13 +196,13 @@ class CommunicationTokenCredentialTests: XCTestCase {
         let expectedToken = sampleToken
         let expectedTokenExpiry = sampleTokenExpiry
 
-        let options = CommunicationTokenRefreshOptions(
+        let tokenRefreshOptions = CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: false,
             tokenRefresher: fetchTokenSync
         )
 
-        let userCredential = try CommunicationTokenCredential(with: options)
+        let userCredential = try CommunicationTokenCredential(with: tokenRefreshOptions)
         DispatchQueue.global(qos: .utility).async {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(accessToken)
@@ -223,13 +223,13 @@ class CommunicationTokenCredentialTests: XCTestCase {
         let expectedToken = sampleToken
         let expectedTokenExpiry = sampleTokenExpiry
 
-        let option = CommunicationTokenRefreshOptions(
+        let tokenRefreshOptions = CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: false,
             tokenRefresher: fetchTokenAsync
         )
 
-        let userCredential = try CommunicationTokenCredential(with: option)
+        let userCredential = try CommunicationTokenCredential(with: tokenRefreshOptions)
         
         DispatchQueue.global(qos: .utility).async {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in

--- a/sdk/communication/AzureCommunication/Tests/CommunicationTokenCredentialTests.swift
+++ b/sdk/communication/AzureCommunication/Tests/CommunicationTokenCredentialTests.swift
@@ -101,11 +101,12 @@ class CommunicationTokenCredentialTests: XCTestCase {
     func test_RefreshTokenProactively_TokenAlreadyExpired() throws {
         let expectation = XCTestExpectation()
 
-        let userCredential = try CommunicationTokenCredential(
+        let option = CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: true,
-            tokenRefresher: fetchTokenSync
-        )
+            tokenRefresher: fetchTokenSync)
+        
+        let userCredential = try CommunicationTokenCredential(with: option)
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
@@ -124,11 +125,13 @@ class CommunicationTokenCredentialTests: XCTestCase {
     func test_RefreshTokenProactively_FetchTokenReturnsError() throws {
         let expectation = XCTestExpectation()
 
-        let userCredential = try CommunicationTokenCredential(
+        let option =  CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: true,
             tokenRefresher: fetchTokenSyncWithError
         )
+        
+        let userCredential = try CommunicationTokenCredential(with: option)
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
@@ -156,12 +159,14 @@ class CommunicationTokenCredentialTests: XCTestCase {
 
             let expiringToken = generateTokenValidForMinutes(minutes)
 
-            let userCredential = try CommunicationTokenCredential(
+            let option = CommunicationTokenRefreshOptions(
                 initialToken: expiringToken,
                 refreshProactively: true,
                 tokenRefresher: fetchTokenSync
             )
 
+            let userCredential = try CommunicationTokenCredential(with: option)
+            
             DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
                 userCredential.token { (accessToken: CommunicationAccessToken?, _: Error?) in
                     XCTAssertNotNil(accessToken)
@@ -191,12 +196,13 @@ class CommunicationTokenCredentialTests: XCTestCase {
         let expectedToken = sampleToken
         let expectedTokenExpiry = sampleTokenExpiry
 
-        let userCredential = try CommunicationTokenCredential(
+        let options = CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: false,
             tokenRefresher: fetchTokenSync
         )
 
+        let userCredential = try CommunicationTokenCredential(with: options)
         DispatchQueue.global(qos: .utility).async {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(accessToken)
@@ -217,12 +223,14 @@ class CommunicationTokenCredentialTests: XCTestCase {
         let expectedToken = sampleToken
         let expectedTokenExpiry = sampleTokenExpiry
 
-        let userCredential = try CommunicationTokenCredential(
+        let option = CommunicationTokenRefreshOptions(
             initialToken: sampleExpiredToken,
             refreshProactively: false,
             tokenRefresher: fetchTokenAsync
         )
 
+        let userCredential = try CommunicationTokenCredential(with: option)
+        
         DispatchQueue.global(qos: .utility).async {
             userCredential.token { (accessToken: CommunicationAccessToken?, error: Error?) in
                 XCTAssertNotNil(accessToken)

--- a/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialAsyncTests.m
+++ b/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialAsyncTests.m
@@ -51,17 +51,21 @@ NSString const * kSampleTokenSignature = @"adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fS
     __weak ObjCCommunicationTokenCredentialAsyncTests *weakSelf = self;
     
     NSString *token = [self generateTokenValidForMinutes: 1];
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                               initWithInitialToken:token
-                                               refreshProactively:YES
-                                               error:nil
-                                               tokenRefresher:
-                                               ^(void (^ block)
-                                                 (NSString * _Nullable newToken,
-                                                  NSError * _Nullable error)) {
+    
+    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+                                                initWithInitialToken:token
+                                                refreshProactively:YES
+                                                tokenRefresher:
+                                                ^(void (^ block)
+                                                  (NSString * _Nullable newToken,
+                                                   NSError * _Nullable error)) {
         weakSelf.fetchTokenCallCount += 1;
         block(weakSelf.sampleToken, nil);
     }];
+    
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWith: option
+                                                error: nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,
                                              NSError * _Nullable error) {
@@ -81,17 +85,20 @@ NSString const * kSampleTokenSignature = @"adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fS
     __weak ObjCCommunicationTokenCredentialAsyncTests *weakSelf = self;
     
     NSString *token = [self generateTokenValidForMinutes: 9];
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                               initWithInitialToken:token
-                                               refreshProactively:YES
-                                               error:nil
-                                               tokenRefresher:
-                                               ^(void (^ block)
-                                                 (NSString * _Nullable newToken,
-                                                  NSError * _Nullable error)) {
+    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+                                                initWithInitialToken:token
+                                                refreshProactively:YES
+                                                tokenRefresher:
+                                                ^(void (^ block)
+                                                  (NSString * _Nullable newToken,
+                                                   NSError * _Nullable error)) {
         weakSelf.fetchTokenCallCount += 1;
         block(weakSelf.sampleToken, nil);
     }];
+    
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWith:option
+                                                error:nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,
                                              NSError * _Nullable error) {

--- a/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialAsyncTests.m
+++ b/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialAsyncTests.m
@@ -52,7 +52,7 @@ NSString const * kSampleTokenSignature = @"adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fS
     
     NSString *token = [self generateTokenValidForMinutes: 1];
     
-    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+    CommunicationTokenRefreshOptions *tokenRefreshOptions = [[CommunicationTokenRefreshOptions alloc]
                                                 initWithInitialToken:token
                                                 refreshProactively:YES
                                                 tokenRefresher:
@@ -64,7 +64,7 @@ NSString const * kSampleTokenSignature = @"adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fS
     }];
     
     CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                                initWith: option
+                                                initWith: tokenRefreshOptions
                                                 error: nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,
@@ -85,7 +85,7 @@ NSString const * kSampleTokenSignature = @"adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fS
     __weak ObjCCommunicationTokenCredentialAsyncTests *weakSelf = self;
     
     NSString *token = [self generateTokenValidForMinutes: 9];
-    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+    CommunicationTokenRefreshOptions *tokenRefreshOptions = [[CommunicationTokenRefreshOptions alloc]
                                                 initWithInitialToken:token
                                                 refreshProactively:YES
                                                 tokenRefresher:
@@ -97,7 +97,7 @@ NSString const * kSampleTokenSignature = @"adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fS
     }];
     
     CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                                initWith:option
+                                                initWith:tokenRefreshOptions
                                                 error:nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,

--- a/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialTests.m
+++ b/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialTests.m
@@ -69,7 +69,7 @@
                                       @"RefreshTokenProactively_TokenAlreadyExpired"];
     __weak ObjCCommunciationTokenCredentialTests *weakSelf = self;
     
-    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+    CommunicationTokenRefreshOptions *tokenRefreshOptions = [[CommunicationTokenRefreshOptions alloc]
                                                 initWithInitialToken:self.sampleExpiredToken
                                                 refreshProactively:YES
                                                 tokenRefresher:^(void (^ block)
@@ -80,7 +80,7 @@
     }];
     
     CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                                initWith:option
+                                                initWith:tokenRefreshOptions
                                                 error:nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,
@@ -101,7 +101,7 @@
                                       @"RefreshTokenProactively_FetchTokenReturnsError"];
     __weak ObjCCommunciationTokenCredentialTests *weakSelf = self;
     NSString *errorDesc = @"Error while fetching token";
-    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+    CommunicationTokenRefreshOptions *tokenRefreshOptions = [[CommunicationTokenRefreshOptions alloc]
                                                 initWithInitialToken:self.sampleExpiredToken
                                                 refreshProactively:YES
                                                 tokenRefresher:^(void (^ block)
@@ -116,7 +116,7 @@
     }];
     
     CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                                initWith:option
+                                                initWith:tokenRefreshOptions
                                                 error:nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,

--- a/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialTests.m
+++ b/sdk/communication/AzureCommunication/Tests/ObjCCommunicationTokenCredentialTests.m
@@ -50,8 +50,9 @@
     XCTestExpectation *expectation = [self expectationWithDescription:
                                       @"DecodeToken"];
 
-    CommunicationTokenCredential *userCredential = [[CommunicationTokenCredential alloc] initWithToken: self.sampleToken
-                                                                                               error: nil];
+    CommunicationTokenCredential *userCredential = [[CommunicationTokenCredential alloc]
+                                                    initWithToken: self.sampleToken
+                                                    error: nil];
     
     [userCredential tokenWithCompletionHandler:^(CommunicationAccessToken *accessToken, NSError * error) {
         XCTAssertNil(error);
@@ -68,16 +69,19 @@
                                       @"RefreshTokenProactively_TokenAlreadyExpired"];
     __weak ObjCCommunciationTokenCredentialTests *weakSelf = self;
     
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                               initWithInitialToken:self.sampleExpiredToken
-                                               refreshProactively:YES
-                                               error:nil
-                                               tokenRefresher:^(void (^ block)
-                                                                (NSString * _Nullable accessToken,
-                                                                 NSError * _Nullable error)) {
+    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+                                                initWithInitialToken:self.sampleExpiredToken
+                                                refreshProactively:YES
+                                                tokenRefresher:^(void (^ block)
+                                                                 (NSString * _Nullable accessToken,
+                                                                  NSError * _Nullable error)) {
         weakSelf.fetchTokenCallCount += 1;
         block(weakSelf.sampleToken, nil);
     }];
+    
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWith:option
+                                                error:nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,
                                              NSError * _Nullable error) {
@@ -97,13 +101,12 @@
                                       @"RefreshTokenProactively_FetchTokenReturnsError"];
     __weak ObjCCommunciationTokenCredentialTests *weakSelf = self;
     NSString *errorDesc = @"Error while fetching token";
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                               initWithInitialToken:self.sampleExpiredToken
-                                               refreshProactively:YES
-                                               error:nil
-                                               tokenRefresher:^(void (^ block)
-                                                                (NSString * _Nullable token,
-                                                                 NSError * _Nullable error)) {
+    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+                                                initWithInitialToken:self.sampleExpiredToken
+                                                refreshProactively:YES
+                                                tokenRefresher:^(void (^ block)
+                                                                 (NSString * _Nullable token,
+                                                                  NSError * _Nullable error)) {
         weakSelf.fetchTokenCallCount += 1;
         
         NSDictionary *errorDictionary = @{ NSLocalizedDescriptionKey: errorDesc};
@@ -111,6 +114,10 @@
         
         block(nil, error);
     }];
+    
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWith:option
+                                                error:nil];
     
     [credential tokenWithCompletionHandler:^(CommunicationAccessToken * _Nullable accessToken,
                                              NSError * _Nullable error) {

--- a/sdk/communication/AzureCommunication/Tests/ObjCTokenParserTests.m
+++ b/sdk/communication/AzureCommunication/Tests/ObjCTokenParserTests.m
@@ -57,7 +57,7 @@
     NSString *invalidToken = @"foo.bar";
     NSError *error = nil;
     
-    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+    CommunicationTokenRefreshOptions *tokenRefreshOptions = [[CommunicationTokenRefreshOptions alloc]
                                                 initWithInitialToken:invalidToken
                                                 refreshProactively:YES
                                                 tokenRefresher:^(void (^ _Nonnull block)
@@ -66,7 +66,7 @@
     }];
     
     CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
-                                                initWith:option
+                                                initWith:tokenRefreshOptions
                                                 error:&error];
     
     XCTAssertNil(credential);

--- a/sdk/communication/AzureCommunication/Tests/ObjCTokenParserTests.m
+++ b/sdk/communication/AzureCommunication/Tests/ObjCTokenParserTests.m
@@ -36,8 +36,9 @@
 - (void)xtest_ObjCThrowsIfInvalidTokenFoo {
     NSString *invalidFoo = @"foo";
     NSError *error = nil;
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc] initWithToken:invalidFoo
-                                                                                           error:&error];
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWithToken:invalidFoo
+                                                error:&error];
     XCTAssertNil(credential);
     XCTAssertNotNil(error);
 }
@@ -45,8 +46,9 @@
 - (void)xtest_ObjCThrowsIfInvalidTokenFormat {
     NSString *invalidToken = @"foo.bar.foobar";
     NSError *error = nil;
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc] initWithToken:invalidToken
-                                                                                           error:&error];
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWithToken:invalidToken
+                                                error:&error];
     XCTAssertNil(credential);
     XCTAssertNotNil(error);
 }
@@ -54,13 +56,18 @@
 - (void)xtest_ObjCThrowsWhenInitWithBlock {
     NSString *invalidToken = @"foo.bar";
     NSError *error = nil;
-    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc] initWithInitialToken:invalidToken
-                                                                                     refreshProactively:YES
-                                                                                                  error:&error
-                                                                                         tokenRefresher:^(void (^ _Nonnull block)
-                                                                                                          (NSString * _Nullable token,
-                                                                                                           NSError * _Nullable error)) {
+    
+    CommunicationTokenRefreshOptions *option = [[CommunicationTokenRefreshOptions alloc]
+                                                initWithInitialToken:invalidToken
+                                                refreshProactively:YES
+                                                tokenRefresher:^(void (^ _Nonnull block)
+                                                                 (NSString * _Nullable token,
+                                                                  NSError * _Nullable error)) {
     }];
+    
+    CommunicationTokenCredential *credential = [[CommunicationTokenCredential alloc]
+                                                initWith:option
+                                                error:&error];
     
     XCTAssertNil(credential);
     XCTAssertNotNil(error);


### PR DESCRIPTION
As per arch review. We want to encapsulate CommunicationUserCredential params into TokenRefreshOptions. 