### PR TITLE
[Communication] - Identifiers - Teams property renamed to userId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.8 (Unreleased)
 
+### Breaking Changes
+- Azure Communication Common Library
+ - Communication identifier `MicrosoftTeamsUserIdentifier` property `identifier` renamed to `userId` since identifier was too generic. 
+ 
 ## 1.0.0-beta.7 (2021-01-12)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 ### Breaking Changes
 - Azure Communication Common Library
  - Communication identifier `MicrosoftTeamsUserIdentifier` property `identifier` renamed to `userId` since identifier was too generic.
- - Removing `CommunicationUserCredentialPolicy`, this policy was a duplicate of cores `BearerTokenCredentialPolicy`. 
- Communication now has new ability to create `BearerTokenCredentialPolicy` using the new `CommunicationPolicyTokenCredential`. 
  
 ## 1.0.0-beta.7 (2021-01-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Breaking Changes
 - Azure Communication Common Library
- - Communication identifier `MicrosoftTeamsUserIdentifier` property `identifier` renamed to `userId` since identifier was too generic. 
+ - Communication identifier `MicrosoftTeamsUserIdentifier` property `identifier` renamed to `userId` since identifier was too generic.
+ - Removing `CommunicationUserCredentialPolicy`, this policy was a duplicate of cores `BearerTokenCredentialPolicy`. 
+ Communication now has new ability to create `BearerTokenCredentialPolicy` using the new `CommunicationPolicyTokenCredential`. 
  
 ## 1.0.0-beta.7 (2021-01-12)
 

--- a/sdk/communication/AzureCommunication/Source/Identifiers.swift
+++ b/sdk/communication/AzureCommunication/Source/Identifiers.swift
@@ -86,15 +86,15 @@ import Foundation
  Communication identifier for Microsoft Teams Users
  */
 @objcMembers public class MicrosoftTeamsUserIdentifier: NSObject, CommunicationIdentifier {
-    public let identifier: String
+    public let userId: String
     public let isAnonymous: Bool
     /**
      Creates a MicrosoftTeamsUserIdentifier object
-     - Parameter identifier: Id of the Microsoft Teams user. If the user isn't anonymous, the id is the AAD object id of the user.
+     - Parameter userId: Id of the Microsoft Teams user. If the user isn't anonymous, the id is the AAD object id of the user.
      - Parameter isAnonymous: Set this to true if the user is anonymous, for example when joining a meeting with a share link.
      */
-    public init(identifier: String, isAnonymous: Bool = false) {
-        self.identifier = identifier
+    public init(userId: String, isAnonymous: Bool = false) {
+        self.userId = userId
         self.isAnonymous = isAnonymous
     }
 }


### PR DESCRIPTION
Renaming from `identifier` to `userId` in case `identifier` needs to be used for different purpose in the future. Specifically only for `MicrosoftTeamsUserIdentifier`