### PR TITLE
[DO NOT MERGE] AzureCommunicationCalling API Review

### DIFF
--- a/sdk/communication/AzureCommunicationCalling/ApiSamples.md
+++ b/sdk/communication/AzureCommunicationCalling/ApiSamples.md
@@ -1,0 +1,754 @@
+# Azure Communication Calling iOS API Samples
+
+<!-- Note: We may want to add a section for terminology explanation. Eg. what's CallClient vs CallAgent etc. -->
+
+## Overview
+- ### [Start with CallClient and CallAgent](#start-with-callclient-and-callagent)
+- ### [Call Basics](#call-basics)
+- ### [Video Basics](#video-basics)
+- ### [Device Management](#device-management)
+- ### [Push Notification](#push-notification)
+- ### [Remote Participant Management](#remote-participant-management)
+
+## Start with CallClient and CallAgent
+<!--Start Start with CallClient and CallAgent-->
+### Initialization
+Create a CallClient instance and call createCallAgent api to get CallAgent instance. Make sure you have imported "AzureCommunication.framework" and "AzureCore.framework"
+
+* Create CommunicationTokenCredential object so that SDK can fetch token
+```swift
+    import AzureCommunication
+
+    let tokenString = "token_string";
+    var userCredential: CommunicationTokenCredential?
+    do {
+        userCredential = try CommunicationTokenCredential(with: CommunicationTokenRefreshOptions(initialToken: token, 
+                                                                    refreshProactively: true,
+                                                                    tokenRefresher: self.fetchTokenSync))
+    } catch {
+        print("Failed to create CommunicationTokenCredential object")
+    }
+
+    self.tokenProvider = ContosoTokenProvider()
+    /*self.tokenProvider is Contoso's internal implementation that fetches token from Contoso server*/
+    public func fetchTokenSync(then onCompletion: TokenRefreshOnCompletion) {
+        let newToken = self.tokenProvider.getToken()
+        onCompletion(newToken, nil)
+    }
+```
+
+* Pass CommunicationUserCredential object created above to CallClient
+```swift
+public class CallingApp : NSObject, CallAgentDelegate, IncomingCallDelegate
+{
+    var callClient: CallClient?
+    var callAgent: CallAgent?
+    var callObserver: CallObserver?
+    var deviceManager: DeviceManager?
+
+    func init()
+    {
+        self.callClient = CallClient()
+        let options = CallAgentOptions()!
+        options.displayName = displayName
+        self.callClient!.createCallAgent(
+            userCredential: userCredential!,
+            options: options,
+            completionHandler: { (callAgent, error) in
+                if error != nil {
+                    print("Create agent succeeded")
+                    self.callAgent = callAgent
+                    self.callClient!.getDeviceManager(
+                        completionHandler: { (deviceManager, error) in
+                            if (error == nil) {
+                                print("Got device manager instance")
+                                self.deviceManager = deviceManager
+                            } else {
+                                print("Failed to get device manager instance")
+                            }
+                } else {
+                    print("Create agent failed")
+                }
+            })
+        self.callObserver = CallObserver()
+    }
+
+    // Event raised to get notified when call collection on CallAgent is added/removed
+    public func onCallsUpdated(_ callAgent: CallAgent!, args: CallsUpdatedEventArgs!) {
+        // Add application logic when call is added
+        args.addedCalls?.forEach { call in }
+
+        // Add application logic when call is removed
+        args.removedCalls?.forEach { call in }
+    }
+
+    // Event raised when there is an incoming call
+    public func onIncomingCall(_ callAgent: CallAgent!, incomingcall: IncomingCall!) {
+        self.incomingCall = incomingcall
+        // Subscribe to get OnCallEnded event
+        self.incomingCall!.delegate = self
+    }
+
+    // Event raised when incoming call was not answered
+    public func onCallEnded(_ incomingCall: IncomingCall!, args: PropertyChangedEventArgs!) {
+        self.incomingCall = nil
+    }
+}
+```
+<!--End Start with CallClient and CallAgent-->
+
+## Call Basics
+<!--Start Call Basics-->
+### Call Properties
+Call object has various properties
+```swift
+// [String] caller identity
+self.call.id
+
+// CallStateNone = 0,CallStateEarlyMedia = 1,CallStateIncoming = 2,CallStateConnecting = 3,CallStateRinging = 4,CallStateConnected = 5,CallStateHold = 6,CallStateDisconnecting = 7,CallStateDisconnected = 8
+self.call.state
+
+// CallDirectionOutgoing = 1, CallDirectionIncoming = 2
+self.call.callDirection
+
+// [Bool] isMicrophoneMuted - is local audio muted
+self.call.isMicrophoneMuted
+
+// [Errror] callEndReason - containing code/subcode/message indicating how call ended
+self.call.callEndReason
+
+// String[] localVideoStreams - collection of video streams send to other participants in a call
+self.call.localVideoStreams
+
+// RemoteParticipant[] remoteParticipants - collection of remote participants participating in this call
+self.call.remoteParticipants
+
+// Indicates if the call is currently being recorded or not
+self.call.isRecordingActive;
+```
+
+### Call Operations
+* ### Make Outgoing Call
+
+To create and start a call you need to call one of the APIs on CallAgent
+```swift
+public class CallManager : NSObject, CallDelegate
+{
+    public func placeCall(names: [CommunicationIdentifier])
+    {
+        let callOptions = StartCallOptions()!
+        // Using the CallAgent received from the factory method
+        // and returns a Call object
+        let audioOptions = AudioOptions()
+        audioOptions!.muted = true // Start the call in mute state
+        callOptions.audioOptions = audioOptions
+        let call = self.callAgent!.startCall(participants: names,
+                                            options: callOptions)
+        call!.delegate = self.callObserver
+    }
+
+    public func placeVideoCall(names: [CommunicationIdentifier])
+    {
+        let camera = self.deviceManager!.cameras!.first
+        let localVideoStream = LocalVideoStream(camera: camera)
+        let videoOptions = VideoOptions(localVideoStream: localVideoStream)
+        
+        let callOptions = StartCallOptions()
+        callOptions?.videoOptions = videoOptions
+
+        let call = self.callAgent?.startCall(participants: names,
+                                                options: callOptions)
+        call!.delegate = self.callObserver
+    }
+
+    // Following is one event which is part of CallDelegate
+    public func OnStateChanged(_ call: Call!,
+                                args: PropertyChangedEventArgs!)
+    {
+        let state = CallObserver.callStateToString(state: call.state)
+        print("Call state changed to %@", state)
+    }
+}
+
+```
+
+* ### Accept Incoming Call
+
+To accept a call you need to call one of the APIs on CallAgent
+```swift
+public class CallManager : NSObject
+{
+    public func acceptCall()
+    {
+        let acceptCallOptions = AcceptCallOptions()!
+        let camera = self.deviceManager!.cameras!.first
+        let localVideoStream = LocalVideoStream(camera: camera)
+        let videoOptions = VideoOptions(localVideoStream: localVideoStream)
+        acceptCallOptions.videoOptions = videoOptions
+        self.incomingCall!.accept(options: acceptCallOptions) { (call, error) in
+            if(error == nil) {
+                self.call = call
+                self.callObserver = CallObserver(view:self)
+                self.call!.delegate = self.callObserver
+            } else {
+                print("[IncomingCall] Accepting call failed")
+            }
+        }
+    }
+
+    public func rejectCall()
+    {
+        s
+    }
+}
+```
+
+* ### Join Call
+
+To join a call you need to call one of the APIs on CallClient
+```swift
+public class CallManager : NSObject
+{
+    public func joinCall(threadId: String)
+    {
+        let options = JoinCallOptions()!
+        self.localVideoStream = LocalVideoStream(camera: self.deviceManager!.cameras!.first)
+        options.videoOptions = VideoOptions(localVideoStream: self.localVideoStream!)!
+        let audioOptions = AudioOptions()!
+        audioOptions.muted = true // Join group call muted
+        options.audioOptions = audioOptions
+        if (threadId.starts(with: "http")) {
+            // Join a meeting with link
+            let teamsMeetingLinkLocator = TeamsMeetingLinkLocator(meetingLink: threadId)!;
+            self.call = self.callAgent?.join(with: teamsMeetingLinkLocator, joinCallOptions: options)
+        } else {
+            let groupCallLocator = GroupCallLocator(groupId: UUID(uuidString: threadId))!
+            self.call = self.callAgent?.join(with: groupCallLocator, joinCallOptions: options)
+        }
+        // Get updates on the call
+        self.call.delegate = self.callObserver
+    }
+}
+```
+
+* ### Mute/Unmute
+
+[Asynchronous] Local mute
+
+```swift
+self.call?.mute(completionHandler: { (error) in
+    if error == nil {
+        print("Successfully muted")
+    } else {
+        print("Failed to mute")
+    }
+})
+
+```
+[Asynchronous] Local unmute
+
+```swift
+call.unmute(completionHandler:{ (error) in
+    if error == nil {
+        print("Successfully unmuted")
+    } else {
+        print("Failed to unmute")
+    }
+})
+```
+
+* ### HangUp Call
+To hangUp the call:
+```swift
+var hangUpOptions = HangUpOptions()!
+hangUpOptions.forEveryOne = true
+self.call.hangUp(hangUpOptions) { (error) in
+    if (error == nil) {
+        print("HangUp successfull")
+    } else {
+        print("HangUp failed, try again")
+    }
+}
+print(CallObserver.callStateToString(state:call.state)) // => Disconnecting -> Disconnected
+```
+
+### Call Event Handling
+
+#### Event model
+Most of properties and collections can change it's value.
+To subscribe to these changes you can use following:
+* ##### Properties
+Application should implement the delegate to get notfied for change in properties
+```swift
+    self.call.delegate = CallObserver()
+    // Get the property of the call state by doing get on the call's state member
+    public func OnStateChanged(_ call: Call!,
+                                args: PropertyChangedEventArgs!)
+    {
+        print("Callback from SDK when the call state changes, current state: " + CallObserver.callStateToString(state:call.state))
+    }
+```
+
+* ##### Collections
+To subscribe to collection updated event also delegate needs to be implemented
+to get notfified when there is a change in collection
+```swift
+    self.call.delegate = self
+    // Collection contains the streams that were added or removed only
+    public func onLocalVideoStreamsChanged(_ call: Call!,
+                                           args: LocalVideoStreamsUpdatedEventArgs!)
+    {
+        print(args.addedStreams.count);
+        print(args.removedStreams.count);
+    }
+```
+
+To unsubscribe:
+```swift
+self.call.delegate = nil // Will not recieve anymore call updates
+self.callClient.delegate = nil // Will not get incoming call notification
+self.incomingCall.delegate = nil // Will not get when incoming call end notification
+```
+
+#### Examples
+Call event handler for call object created when incoming call is answered or when placing an outgoing call succeeds
+
+```swift
+public class CallObserver : NSObject, CallDelegate
+{
+    public static func callStateToString(state: CallState) -> String {
+        switch state {
+            case .connected: return "Connected"
+            case .connecting: return "Connecting"
+            case .disconnected: return "Disconnected"
+            case .disconnecting: return "Disconnecting"
+            case .earlyMedia: return "EarlyMedia"
+            case .localHold: return "LocalHold"
+            case .remoteHold: return "RemoteHold"
+            case .none: return "None"
+            case .ringing: return "Ringing"
+            case .inLobby: return "InLobby"
+            default: return "Unknown"
+        }
+    }
+
+    public func OnStateChanged(_ call: Call!,
+                                args: PropertyChangedEventArgs!)
+    {
+        print("Call state changed to: " + callStateToString(state:call.state));
+    }
+
+    public func onRemoteParticipantsUpdated(_ call: Call!,
+                                                args: ParticipantsUpdatedEventArgs!)
+    {
+        print(args.addedParticipants.count);
+        print(args.removedParticipants.count);
+    }
+
+    public func onVideoStreamsUpdated(_ remoteParticipant: RemoteParticipant!,
+                                        args: RemoteVideoStreamsEventArgs!)
+    {
+        print(args.addedStreams.count);
+        print(args.removedStreams.count);
+    }
+
+    public func onIsRecordingActiveChanged(_ call: Call!, args: PropertyChangedEventArgs!) {
+        print("Call recording state changed to " + call.isRecordingActive)
+    }
+
+    public func onLocalVideoStreamsChanged(_ call: Call!, args: LocalVideoStreamsUpdatedEventArgs!) {
+        print("Added streams count: " + args.addedStreams)
+        print("Removed streams count: " + args.addedStreams)
+    }
+
+    public func onIdChanged:(_ call: Call!, args: PropertyChangedEventArgs!) {
+        print("Call id has changed: oldValue: \(self.call.id), newValue: \(call.id)")
+    }
+}
+```
+
+* list existing ongoing calls that local user is part of
+```swift
+for call in self.callClient.calls { print(call); } // [Call, Call, Call...]
+```
+* subscribe to added/removed call
+```swift
+self.callObserver = CallObserver()
+
+public func onCallsUpdated(_ callAgent: CallAgent!,
+                           args: CallsUpdatedEventArgs!)
+{
+    for addedCall in args.addedCalls { print(addedCall); }
+    for removedCall in args.removedCalls { print(removedCall); }
+}
+
+```
+
+### Call Options
+* Different call options, you can pass additional options when call is created and started to control 
+which audio/video streams that will be used to start a call. (Devices have to obtained by enumerating devices using deviceManager)
+```swift
+var startCallOptions = StartCallOptions()
+var joinCallOptions = JoinCallOptions()
+var acceptCallOptions = AcceptCallOptions()
+
+var videoOptions = VideoOptions()
+var audioOptions = AudioOptions()
+
+// start with selected camera
+videoOptions.camera = deviceManager?.cameras?.first
+// start call muted
+audioOptions.muted = true
+```
+
+* State transition when call starts
+```swift
+// => None -> Connecting -> Ringing -> Connected
+print(CallObserver.callStateToString(state:self.call?.state))
+// every remote participant state will transition idependently: Idle -> Connecting -> Connected
+for remoteParticipant in self.call?.remoteParticipants { print(CallObserver.callStateToString(state: remoteParticipant.state)) }
+
+```
+<!--End Call Basics-->
+
+## Video Basics
+<!--Start Video Basics-->
+### Start / Stop Video
+* [Asynchronous] Start/stop video using the call object
+```swift
+let firstCamera: VideoDeviceInfo? = self.deviceManager?.cameras?.first
+let localVideoStream = LocalVideoStream(camera: firstCamera)
+let videoOptions = VideoOptions(localVideoStream: localVideoStream)
+
+self.call?.startVideo(stream: localVideoStream) { (error) in
+    if (error == nil) {
+        print("Local video started successfully")
+    } else {
+        print("Local video failed to start")
+    }
+}
+
+self.call?.stopVideo(stream: localVideoStream!) { (error) in
+    if (error == nil) {
+        print("Local video stopped successfully")
+    } else {
+        print("Local video failed to stop")
+    }
+}
+```
+
+### Local Video Preview
+You can use Renderer to start render stream from your local camera, this stream won't be send to other participants, it's local preview feed
+* [Synchronous] Start local video preview
+```swift
+let firstCamera: VideoDeviceInfo? = self.deviceManager?.cameras?.first
+let localVideoStream = LocalVideoStream(camera: firstCamera)
+let previewRenderer = try! Renderer(localVideoStream: localVideoStream)
+let previewView = try! previewRenderer!.createView(with: RenderingOptions(scalingMode:scalingMode))
+
+rendererObserver = RendererObserver(view: self)
+previewView!.delegate = rendererObserver
+```
+
+```swift
+public class RendererObserver: NSObject, RendererDelegate {
+    let view: View
+    init(view: View) {
+        self.view = view
+    }
+
+    public func onFirstFrameRendered() {
+        print("Size of frame is " + view.renderer!.size)
+    }
+
+    public func rendererFailedToStart() {
+        print("Rederer failed to start")
+    }
+}
+```
+
+Renderer has set of properties and methods that allows you to control it:
+```swift
+// Constructor can take in LocalVideoStream or RemoteVideoStream
+let localRenderer = Renderer(localVideoStream:localVideoStream)
+let remoteRenderer = Renderer(remoteVideoStream:remoteVideoStream)
+
+// [StreamSize] size of the rendering view
+renderer.size
+
+// [RendererDelegate] an object you provide to receive events from this Renderer instance
+renderer.delegate
+
+// [Synchronous] create view with rendering options
+renderer!.createView(with: RenderingOptions(scalingMode:ScalingMode.crop));
+// [Synchronous] dispose rendering view
+renderer.dispose();
+```
+
+### Switch Video Source
+* [Asynchronous] Switch local video, pass localVideoStream you got from call.startVideo() API call
+```swift
+// get camera
+var firstCamera = self.deviceManager?.cameras?.first
+
+localVideoStream?.switchSource(firstCamera, completionHandler: { (error) in
+    if (error == nil) {
+        print("Successfully switched to new source")
+    } else {
+        print("Failed to switch to new source")
+    }
+})
+```
+<!--End Video Basics-->
+
+## Device Management
+<!--Start Device Management-->
+### Microphone / Speaker
+Device mananager allows you to set device that will be used when starting a call
+If not  will fallback to OS defaults
+
+#### Get / Set Devices
+```swift
+// get microphone
+var firstMicrophone = self.deviceManager?.microphones?.first
+
+// get speaker
+var firstSpeaker = self.deviceManager?.speakers?.first
+
+// [Synchronous] set microphone
+self.deviceManager?.setMicrophone(microphoneDevice: firstMicrophone)
+
+// [Synchronous] set speaker
+self.deviceManager?.setSpeaker(speakerDevice: firstSpeaker)
+```
+
+AudioDeviceInfo has a set of properties:
+```swift
+var audioDeviceInfo = self.deviceManager?.microphones?.first
+
+// [NSString] name of the audio device
+audioDeviceInfo?.name
+
+// [NSString] id of the audio device
+audioDeviceInfo?.id
+
+// [BOOL] true if device is a system default
+audioDeviceInfo?.isSystemDefault
+
+// [AudioDeviceType] type of the audio device
+audioDeviceInfo?.deviceType
+```
+
+#### Enumerate Local Devices
+Enumeration is synchronous
+```swift
+// enumerate local cameras
+var localCameras = self.CallingApp.deviceManager!.cameras // [VideoDeviceInfo, VideoDeviceInfo...]
+// enumerate local cameras
+var localMicrophones = self.CallingApp.deviceManager!.microphones // [AudioDeviceInfo, AudioDeviceInfo...]
+// enumerate local cameras
+var localSpeakers = self.CallingApp.deviceManager!.speakers // [AudioDeviceInfo, AudioDeviceInfo...]
+
+```
+
+<!--End Device Management-->
+
+## Push Notification
+<!--Start Push Notification-->
+
+### Push Notification APIs
+
+#### Register for Push Notification
+
+- In order to register for push notification, call registerPushNotification() on a *CallAgent* instance with a device registration token.
+
+```swift
+let deviceToken: Data = pushRegistry?.pushToken(for: PKPushType.voIP)
+self.callAgent?.registerPushNotifications(deviceToken: deviceToken) { (error) in
+                    if(error == nil) {
+                        print("Successfully register to push notification.")
+                    } else {
+                        print("Failed to register push notification.")
+                    }
+                })
+```
+
+#### Push Notification Handling
+- In order to receive incoming calls push notifications, call *handlePushNotification()* on a *CallAgent* instance with a dictionary payload.
+
+```swift
+
+let callNotification = IncomingCallPushNotification.from(payload: pushPayload?.dictionaryPayload)
+
+self.callAgent?.handlePush(notification: callNotification) { (error) in
+            if (error != nil) {
+                print("Handling of push notification failed")
+            } else {
+                print("Handling of push notification was successful")
+            }
+        }
+```
+
+#### Unregister Push Notification
+
+- Applications can unregister push notification at any time. Simply call the `unregisterPushNotification()` method on *CallAgent*.
+
+```swift
+self.callAgent?.unRegisterPushNotifications(completionHandler: { (error) in
+                if (error != nil) {
+                    print("Unregister of push notification failed, please try again")
+                } else {
+                    print("Unregister of push notification was successfull")
+                }
+            })
+```
+<!--End Push Notification-->
+
+## Remote Participant Management
+<!--Start Remote Participant Management-->
+
+### Remote Participants Properties
+Remote participant has set of properties
+
+```swift
+// [RemoteParticipantDelegate] delegate - an object you provide to receive events from this RemoteParticipant instance
+var remoteParticipantDelegate = remoteParticipant?.delegate
+
+// [CommunicationIdentifier] identity - same as the one used to provision token for another user
+var identity = remoteParticipant?.identity;
+
+// ParticipantStateIdle = 0, ParticipantStateEarlyMedia = 1, ParticipantStateConnecting = 2, ParticipantStateConnected = 3, ParticipantStateOnHold = 4, ParticipantStateInLobby = 5, ParticipantStateDisconnected = 6
+var state = remoteParticipant?.state;
+
+// [Error] callEndReason - reason why participant left the call, contains code/subcode/message
+var callEndReason = remoteParticipant?.callEndReason
+
+// [Bool] isMuted - indicating if participant is muted
+var isMuted = remoteParticipant?.isMuted;
+
+// [Bool] isSpeaking - indicating if participant is currently speaking
+var isSpeaking = remoteParticipant?.isSpeaking;
+
+// RemoteVideoStream[] - collection of video streams this participants has
+var videoStreams = remoteParticipant?.videoStreams; // [RemoteVideoStream, RemoteVideoStream, ...]
+
+// RemoteVideoStream[] - collection of screen sharing streams this participants has
+var screenSharingStreams = remoteParticipant?.screenSharingStreams; // [RemoteVideoStream, RemoteVideoStream, ...]
+```
+
+### Call Operations for Remote Participant
+#### Add Participant to a Call
+* [Synchronous] Add participant to a call
+```swift
+let remoteParticipantAdded: RemoteParticipant = self.call.add(participant: CommunicationUserIdentifier(identifier: "8:echo123"))
+```
+
+#### Add Phone Number to a Call
+* [Synchronous] Add phone number to a call
+```swift
+let remoteParticipantAdded: RemoteParticipant = self.call.add(participant: PhoneNumberIdentifier(phoneNumber: "+14243333"))
+```
+
+#### Remove Participant from a Call
+* [Asynchronous] Remove participant from a call
+```swift
+self.call?.remove(participant: remoteParticipantAdded) { (error) in
+    if (error == nil) {
+        print("Successfully removed participant")
+    } else {
+        print("Failed to remove participant")
+    }
+}
+```
+
+#### List Participants in a Call
+List all participants in a call
+```swift
+for remoteParticipant in self.call?.remoteParticipants { print(remoteParticipant); } // [RemoteParticipant1, RemoteParticipant2...]
+```
+
+```swift
+public class RemoteParticipantObserver : NSObject, RemoteParticipantDelegate
+{
+    public func onRemoteParticipantsUpdated(_ call: Call!,
+                                            args: ParticipantsUpdatedEventArgs!)
+    {
+        for participant in args.addedParticipants {
+            participant.delegate = self
+            self.remoteParticipants.append(participant)
+        }
+    }
+
+    public func OnStateChanged(_ remoteParticipant: RemoteParticipant!,
+                                args: PropertyChangedEventArgs!)
+    {
+        print("Remote participant " + remoteParticipant.displayName + 
+                " state has changed to " + CallObserver.callStateToString(state: remoteParticipant.state))
+    }
+
+    public func onVideoStreamsUpdated(_ remoteParticipant: RemoteParticipant!,
+                                      args: RemoteVideoStreamsEventArgs!)
+    {
+        print("Status of video stream for participant " + remoteParticipant.displayName)
+        print(args.addedRemoteVideoStreams.count) // Array of added streams
+        print(args.removedRemoteVideoStreams.count) // Array of removed streams
+    }
+
+    public func onIsMuteChanged(_ remoteParticipant: RemoteParticipant!,
+                                      args: PropertyChangedEventArgs!)
+    {
+        print("Remote participant: " + remoteParticipant.displayName + ", is muted: " + remoteParticipant.isMuted)
+    }
+
+    public func onIsSpeakingChanged(_ remoteParticipant: RemoteParticipant!,
+                                      args: PropertyChangedEventArgs!)
+    {
+        print("Remote participant: " + remoteParticipant.displayName + ", is speaking: " + remoteParticipant.isSpeaking)
+    }
+
+    public func onDisplayNameChanged(_ remoteParticipant: RemoteParticipant!,
+                                      args: PropertyChangedEventArgs!)
+    {
+        print("Remote participant new display name: " + remoteParticipant.displayName)
+    }
+}
+```
+
+### Video / Screen Sharing Streams for Remote Participants
+
+To list streams of remote participants inspect his videoStreams or screenSharingStreams collections
+```swift
+var videoStreams: [RemoteVideoStream] = remoteParticipant.videoStreams; // [RemoteVideoStream, RemoteVideoStream ...]
+```
+
+#### RemoteVideoStream
+RemoteVideoStream represents remote video or screen sharing stream that this participant sends in a call
+```swift
+var remoteParticipantVideoStream: RemoteVideoStream  = self.call?.remoteParticipants[0]?.videoStreams[0];
+```
+
+It has following properties:
+```swift
+var type: MediaStreamType = remoteParticipantVideoStream.type; // 'MediaStreamTypeVideo' | 'MediaStreamTypeScreenSharing';
+
+var isAvailable: Bool = remoteParticipantVideoStream.isAvailable; // indicates if remote stream is available
+
+var id: Int = remoteParticipantVideoStream.id // id of remoteParticipantStream
+```
+
+
+#### Render Remote Participant Stream
+* [Synchronous] To start rendering remote participant stream
+```swift
+let renderer: Renderer? = Renderer(remoteVideoStream: remoteParticipantVideoStream)
+let targetRemoteParicipantView: RendererView? = renderer?.createView(with: RenderingOptions(ScalingMode.crop))
+```
+
+* Subscribe to events 
+You can subscribe to one of following events:
+  * 'OnStateChanged'
+  * 'onVideoStreamsUpdated'
+  * 'onIsMutedChanged'
+  * 'onIsSpeakingChanged'
+  * 'onDisplayNameChanged'
+<!--End Remote Participant Management-->

--- a/sdk/communication/AzureCommunicationCalling/ApiSamples.md
+++ b/sdk/communication/AzureCommunicationCalling/ApiSamples.md
@@ -311,9 +311,9 @@ to get notfified when there is a change in collection
 
 To unsubscribe:
 ```swift
-self.call.delegate = nil // Will not recieve anymore call updates
-self.callClient.delegate = nil // Will not get incoming call notification
-self.incomingCall.delegate = nil // Will not get when incoming call end notification
+self.call?.delegate = nil // Will not recieve anymore call updates
+self.callClient?.delegate = nil // Will not get incoming call notification
+self.incomingCall?.delegate = nil // Will not get when incoming call end notification
 ```
 
 #### Examples
@@ -480,15 +480,15 @@ let localRenderer = Renderer(localVideoStream:localVideoStream)
 let remoteRenderer = Renderer(remoteVideoStream:remoteVideoStream)
 
 // [StreamSize] size of the rendering view
-renderer.size
+remoteRenderer?.size
 
 // [RendererDelegate] an object you provide to receive events from this Renderer instance
-renderer.delegate
+remoteRenderer?.delegate
 
 // [Synchronous] create view with rendering options
-renderer!.createView(with: RenderingOptions(scalingMode:ScalingMode.crop));
+remoteRenderer?.createView(with: RenderingOptions(scalingMode:ScalingMode.crop));
 // [Synchronous] dispose rendering view
-renderer.dispose();
+remoteRenderer?.dispose();
 ```
 
 ### Switch Video Source
@@ -549,11 +549,11 @@ audioDeviceInfo?.deviceType
 Enumeration is synchronous
 ```swift
 // enumerate local cameras
-var localCameras = self.CallingApp.deviceManager!.cameras // [VideoDeviceInfo, VideoDeviceInfo...]
+var localCameras = self.deviceManager?.cameras // [VideoDeviceInfo, VideoDeviceInfo...]
 // enumerate local cameras
-var localMicrophones = self.CallingApp.deviceManager!.microphones // [AudioDeviceInfo, AudioDeviceInfo...]
+var localMicrophones = self.deviceManager?.microphones // [AudioDeviceInfo, AudioDeviceInfo...]
 // enumerate local cameras
-var localSpeakers = self.CallingApp.deviceManager!.speakers // [AudioDeviceInfo, AudioDeviceInfo...]
+var localSpeakers = self.deviceManager?.speakers // [AudioDeviceInfo, AudioDeviceInfo...]
 
 ```
 

--- a/sdk/communication/AzureCommunicationCalling/ApiSamples.md
+++ b/sdk/communication/AzureCommunicationCalling/ApiSamples.md
@@ -58,7 +58,7 @@ public class CallingApp : NSObject, CallAgentDelegate, IncomingCallDelegate
                 if error != nil {
                     print("Create agent succeeded")
                     self.callAgent = callAgent
-                    self.callClient!.getDeviceManager(
+                    self.callClient?.getDeviceManager(
                         completionHandler: { (deviceManager, error) in
                             if (error == nil) {
                                 print("Got device manager instance")
@@ -86,7 +86,7 @@ public class CallingApp : NSObject, CallAgentDelegate, IncomingCallDelegate
     public func onIncomingCall(_ callAgent: CallAgent!, incomingcall: IncomingCall!) {
         self.incomingCall = incomingcall
         // Subscribe to get OnCallEnded event
-        self.incomingCall!.delegate = self
+        self.incomingCall?.delegate = self
     }
 
     // Event raised when incoming call was not answered
@@ -103,28 +103,28 @@ public class CallingApp : NSObject, CallAgentDelegate, IncomingCallDelegate
 Call object has various properties
 ```swift
 // [String] caller identity
-self.call.id
+self.call?.id
 
 // CallStateNone = 0,CallStateEarlyMedia = 1,CallStateIncoming = 2,CallStateConnecting = 3,CallStateRinging = 4,CallStateConnected = 5,CallStateHold = 6,CallStateDisconnecting = 7,CallStateDisconnected = 8
-self.call.state
+self.call?.state
 
 // CallDirectionOutgoing = 1, CallDirectionIncoming = 2
-self.call.callDirection
+self.call?.callDirection
 
 // [Bool] isMicrophoneMuted - is local audio muted
-self.call.isMicrophoneMuted
+self.call?.isMicrophoneMuted
 
 // [Errror] callEndReason - containing code/subcode/message indicating how call ended
-self.call.callEndReason
+self.call?.callEndReason
 
 // String[] localVideoStreams - collection of video streams send to other participants in a call
-self.call.localVideoStreams
+self.call?.localVideoStreams
 
 // RemoteParticipant[] remoteParticipants - collection of remote participants participating in this call
-self.call.remoteParticipants
+self.call?.remoteParticipants
 
 // Indicates if the call is currently being recorded or not
-self.call.isRecordingActive;
+self.call?.isRecordingActive;
 ```
 
 ### Call Operations
@@ -142,14 +142,14 @@ public class CallManager : NSObject, CallDelegate
         let audioOptions = AudioOptions()
         audioOptions!.muted = true // Start the call in mute state
         callOptions.audioOptions = audioOptions
-        let call = self.callAgent!.startCall(participants: names,
+        let call = self.callAgent?.startCall(participants: names,
                                             options: callOptions)
-        call!.delegate = self.callObserver
+        call?.delegate = self.callObserver
     }
 
     public func placeVideoCall(names: [CommunicationIdentifier])
     {
-        let camera = self.deviceManager!.cameras!.first
+        let camera = self.deviceManager?.cameras!.first
         let localVideoStream = LocalVideoStream(camera: camera)
         let videoOptions = VideoOptions(localVideoStream: localVideoStream)
         
@@ -158,7 +158,7 @@ public class CallManager : NSObject, CallDelegate
 
         let call = self.callAgent?.startCall(participants: names,
                                                 options: callOptions)
-        call!.delegate = self.callObserver
+        call?.delegate = self.callObserver
     }
 
     // Following is one event which is part of CallDelegate
@@ -181,11 +181,11 @@ public class CallManager : NSObject
     public func acceptCall()
     {
         let acceptCallOptions = AcceptCallOptions()!
-        let camera = self.deviceManager!.cameras!.first
+        let camera = self.deviceManager?.cameras!.first
         let localVideoStream = LocalVideoStream(camera: camera)
         let videoOptions = VideoOptions(localVideoStream: localVideoStream)
         acceptCallOptions.videoOptions = videoOptions
-        self.incomingCall!.accept(options: acceptCallOptions) { (call, error) in
+        self.incomingCall?.accept(options: acceptCallOptions) { (call, error) in
             if(error == nil) {
                 self.call = call
                 self.callObserver = CallObserver(view:self)
@@ -198,7 +198,13 @@ public class CallManager : NSObject
 
     public func rejectCall()
     {
-        s
+        self.incomingCall?.reject { (error) in
+            if (error == nil) {
+                print("Incoming call reject was successfull")
+            } else {
+                print("Incoming call reject failed")
+            }
+        }
     }
 }
 ```

--- a/sdk/communication/AzureCommunicationCalling/ApiSamples.md
+++ b/sdk/communication/AzureCommunicationCalling/ApiSamples.md
@@ -52,14 +52,12 @@ public class CallingApp : NSObject, CallAgentDelegate, IncomingCallDelegate
         let options = CallAgentOptions()!
         options.displayName = displayName
         self.callClient!.createCallAgent(
-            userCredential: userCredential!,
-            options: options,
-            completionHandler: { (callAgent, error) in
+            userCredential: userCredential!, 
+            options: options) { (callAgent, error) in
                 if error != nil {
                     print("Create agent succeeded")
                     self.callAgent = callAgent
-                    self.callClient?.getDeviceManager(
-                        completionHandler: { (deviceManager, error) in
+                    self.callClient!.getDeviceManager { (deviceManager, error) in
                             if (error == nil) {
                                 print("Got device manager instance")
                                 self.deviceManager = deviceManager
@@ -149,7 +147,7 @@ public class CallManager : NSObject, CallDelegate
 
     public func placeVideoCall(names: [CommunicationIdentifier])
     {
-        let camera = self.deviceManager?.cameras!.first
+        let camera = self.deviceManager!.cameras!.first
         let localVideoStream = LocalVideoStream(camera: camera)
         let videoOptions = VideoOptions(localVideoStream: localVideoStream)
         
@@ -158,7 +156,7 @@ public class CallManager : NSObject, CallDelegate
 
         let call = self.callAgent?.startCall(participants: names,
                                                 options: callOptions)
-        call?.delegate = self.callObserver
+        call!.delegate = self.callObserver
     }
 
     // Following is one event which is part of CallDelegate
@@ -242,7 +240,7 @@ public class CallManager : NSObject
 [Asynchronous] Local mute
 
 ```swift
-self.call?.mute(completionHandler: { (error) in
+self.call?.mute { (error) in
     if error == nil {
         print("Successfully muted")
     } else {
@@ -254,7 +252,7 @@ self.call?.mute(completionHandler: { (error) in
 [Asynchronous] Local unmute
 
 ```swift
-call.unmute(completionHandler:{ (error) in
+self.call?.unmute { (error) in
     if error == nil {
         print("Successfully unmuted")
     } else {
@@ -480,15 +478,15 @@ let localRenderer = Renderer(localVideoStream:localVideoStream)
 let remoteRenderer = Renderer(remoteVideoStream:remoteVideoStream)
 
 // [StreamSize] size of the rendering view
-remoteRenderer?.size
+renderer?.size
 
 // [RendererDelegate] an object you provide to receive events from this Renderer instance
-remoteRenderer?.delegate
+renderer?.delegate
 
 // [Synchronous] create view with rendering options
-remoteRenderer?.createView(with: RenderingOptions(scalingMode:ScalingMode.crop));
+renderer?.createView(with: RenderingOptions(scalingMode:ScalingMode.crop));
 // [Synchronous] dispose rendering view
-remoteRenderer?.dispose();
+renderer?.dispose();
 ```
 
 ### Switch Video Source
@@ -497,7 +495,7 @@ remoteRenderer?.dispose();
 // get camera
 var firstCamera = self.deviceManager?.cameras?.first
 
-localVideoStream?.switchSource(firstCamera, completionHandler: { (error) in
+localVideoStream?.switchSource(camera: firstCamera) { (error) in
     if (error == nil) {
         print("Successfully switched to new source")
     } else {
@@ -600,13 +598,13 @@ self.callAgent?.handlePush(notification: callNotification) { (error) in
 - Applications can unregister push notification at any time. Simply call the `unregisterPushNotification()` method on *CallAgent*.
 
 ```swift
-self.callAgent?.unRegisterPushNotifications(completionHandler: { (error) in
-                if (error != nil) {
-                    print("Unregister of push notification failed, please try again")
-                } else {
-                    print("Unregister of push notification was successfull")
-                }
-            })
+self.callAgent?.unRegisterPushNotifications { (error) in
+    if (error != nil) {
+        print("Unregister of push notification failed, please try again")
+    } else {
+        print("Unregister of push notification was successfull")
+    }
+})
 ```
 <!--End Push Notification-->
 

--- a/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/ACSRenderer.h
+++ b/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/ACSRenderer.h
@@ -1,0 +1,33 @@
+//+-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Module name : ACSRenderer.h
+//
+//------------------------------------------------------------------------------
+
+public protocol RendererDelegate : NSObjectProtocol {
+
+    func rendererFailedToStart()
+
+    
+    optional func onFirstFrameRendered()
+}
+
+open class Renderer : NSObject {
+
+    
+    public init(localVideoStream: LocalVideoStream) throws
+
+    public init(remoteVideoStream: RemoteVideoStream) throws
+
+    open func createView() throws -> RendererView
+
+    open func createView(with options: RenderingOptions?) throws -> RendererView
+
+    open func dispose()
+
+    
+    open var size: StreamSize { get }
+
+    unowned(unsafe) open var delegate: RendererDelegate?
+}

--- a/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/ACSRendererView.h
+++ b/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/ACSRendererView.h
@@ -1,0 +1,21 @@
+//+-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Module name : ACSRendererView.h
+//
+//------------------------------------------------------------------------------
+
+import Foundation
+import UIKit
+
+// Forward declaration as importing here causes cyclic dependency
+
+open class RendererView : UIView {
+
+    
+    open func update(scalingMode: ScalingMode)
+
+    open func dispose()
+
+    open func isRendering() -> Bool
+}

--- a/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/ACSStreamSize.h
+++ b/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/ACSStreamSize.h
@@ -1,0 +1,18 @@
+//+-----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Module name : ACSStreamSize.h
+//
+//------------------------------------------------------------------------------
+
+import Foundation
+
+open class StreamSize : NSObject {
+
+    
+    public init(width: Int32, height: Int32)
+
+    open var width: Int32 { get }
+
+    open var height: Int32 { get }
+}

--- a/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/AzureCommunicationCalling.h
+++ b/sdk/communication/AzureCommunicationCalling/Swift_Generated_Interfaces/AzureCommunicationCalling.h
@@ -1,0 +1,1124 @@
+// ACSCallingShared
+// This file was auto-generated from ACSCallingModel.cs.
+
+import Foundation
+
+import AzureCommunication
+//#import <AzureCore/AzureCore-Swift.h>
+
+// Enumerations.
+/// Additional failed states for Azure Communication Services
+public struct CommunicationErrors : OptionSet {
+
+    public init(rawValue: Int)
+
+    
+    /// No Audio permissions available.
+    public static var noAudioPermission: CommunicationErrors { get }
+
+    /// No Video permissions available.
+    public static var noVideoPermission: CommunicationErrors { get }
+
+    /// No Video and Audio permissions available.
+    public static var noAudioAndVideoPermission: CommunicationErrors { get }
+
+    /// Failed to process push notification payload.
+    public static var receivedInvalidPNPayload: CommunicationErrors { get }
+
+    /// Recieved empty/invalid notification payload.
+    public static var failedToProcessPNPayload: CommunicationErrors { get }
+
+    /// Recieved invalid group Id.
+    public static var invalidGuidGroupId: CommunicationErrors { get }
+
+    /// Push notification device registration token is invalid.
+    public static var invalidPNDeviceRegistrationToken: CommunicationErrors { get }
+
+    /// Cannot create multiple renderers for same device or stream.
+    public static var multipleRenderersNotSupported: CommunicationErrors { get }
+
+    /// Renderer doesn't support creating multiple views.
+    public static var multipleViewsNotSupported: CommunicationErrors { get }
+}
+
+/// Direction of the camera
+public enum CameraFacing : Int {
+
+    
+    /// Unknown
+    case unknown = 0
+
+    /// External device
+    case external = 1
+
+    /// Front camera
+    case front = 2
+
+    /// Back camera
+    case back = 3
+
+    /// Panoramic camera
+    case panoramic = 4
+
+    /// Left front camera
+    case leftFront = 5
+
+    /// Right front camera
+    case rightFront = 6
+}
+
+/// Describes the video device type
+public enum VideoDeviceType : Int {
+
+    
+    /// Unknown type of video device
+    case unknown = 0
+
+    /// USB Camera Video Device
+    case usbCamera = 1
+
+    /// Capture Adapter Video Device
+    case captureAdapter = 2
+
+    /// Virtual Video Device
+    case virtual = 3
+
+    /// Augmented Video Device
+    case srAugmented = 4
+}
+
+/// Local and Remote Video Stream types
+public enum MediaStreamType : Int {
+
+    
+    /// Video
+    case video = 0
+
+    /// Screen share
+    case screenSharing = 1
+}
+
+/// State of a participant in the call
+public enum ParticipantState : Int {
+
+    
+    /// Idle
+    case idle = 0
+
+    /// Early Media
+    case earlyMedia = 1
+
+    /// Connecting
+    case connecting = 2
+
+    /// Connected
+    case connected = 3
+
+    /// On Hold
+    case hold = 4
+
+    /// In Lobby
+    case inLobby = 5
+
+    /// Disconnected
+    case disconnected = 6
+
+    /// Ringing
+    case ringing = 7
+}
+
+/// State of a call
+public enum CallState : Int {
+
+    
+    /// None - disposed or applicable very early in lifetime of a call
+    case none = 0
+
+    /// Early Media
+    case earlyMedia = 1
+
+    /// Call is being connected
+    case connecting = 3
+
+    /// Call is ringing
+    case ringing = 4
+
+    /// Call is connected
+    case connected = 5
+
+    /// Call held by local participant
+    case localHold = 6
+
+    /// Call is being disconnected
+    case disconnecting = 7
+
+    /// Call is disconnected
+    case disconnected = 8
+
+    /// In Lobby
+    case inLobby = 9
+
+    /// Call held by a remote participant
+    case remoteHold = 10
+}
+
+/// Directipon of a Call
+public enum CallDirection : Int {
+
+    
+    /// Outgoing call
+    case outgoing = 1
+
+    /// Incoming call
+    case incoming = 2
+}
+
+/// DTMF (Dual-Tone Multi-Frequency) tone for PSTN calls
+public enum DtmfTone : Int {
+
+    
+    /// Zero
+    case zero = 0
+
+    /// One
+    case one = 1
+
+    /// Two
+    case two = 2
+
+    /// Three
+    case three = 3
+
+    /// Four
+    case four = 4
+
+    /// Five
+    case five = 5
+
+    /// Six
+    case six = 6
+
+    /// Seven
+    case seven = 7
+
+    /// Eight
+    case eight = 8
+
+    /// Nine
+    case nine = 9
+
+    /// Star
+    case star = 10
+
+    /// Pound
+    case pound = 11
+
+    /// A
+    case A = 12
+
+    /// B
+    case B = 13
+
+    /// C
+    case C = 14
+
+    /// D
+    case D = 15
+
+    /// Flash
+    case flash = 16
+}
+
+/// Type of audio device
+public enum AudioDeviceType : Int {
+
+    
+    /// Audio device is a microphone
+    case microphone = 0
+
+    /// Audio device is a speaker
+    case speaker = 1
+}
+
+/// Local and Remote Video scaling mode
+public enum ScalingMode : Int {
+
+    
+    /// Cropped
+    case crop = 1
+
+    /// Fitted
+    case fit = 2
+}
+
+public enum HandleType : Int {
+
+    
+    case unknown = 0
+
+    case groupCallLocator = 1
+
+    case teamsMeetingCoordinatesLocator = 2
+
+    case teamsMeetingLinkLocator = 3
+}
+
+// MARK: Forward declarations.
+
+
+/**
+ * A set of methods that are called by ACSInternalTokenProvider in response to important events.
+ */
+public protocol InternalTokenProviderDelegate : NSObjectProtocol {
+
+    
+    optional func onTokenRequested(_ internalTokenProvider: InternalTokenProvider!, sender: InternalTokenProvider!)
+}
+
+
+/**
+ * A set of methods that are called by ACSCallAgent in response to important events.
+ */
+public protocol CallAgentDelegate : NSObjectProtocol {
+
+    
+    optional func onCallsUpdated(_ callAgent: CallAgent!, args: CallsUpdatedEventArgs!)
+
+    optional func onIncomingCall(_ callAgent: CallAgent!, incomingcall: IncomingCall!)
+}
+
+
+/**
+ * A set of methods that are called by ACSCall in response to important events.
+ */
+public protocol CallDelegate : NSObjectProtocol {
+
+    
+    optional func onIdChanged(_ call: Call!, args: PropertyChangedEventArgs!)
+
+    optional func onStateChanged(_ call: Call!, args: PropertyChangedEventArgs!)
+
+    optional func onRemoteParticipantsUpdated(_ call: Call!, args: ParticipantsUpdatedEventArgs!)
+
+    optional func onLocalVideoStreamsChanged(_ call: Call!, args: LocalVideoStreamsUpdatedEventArgs!)
+
+    optional func onIsRecordingActiveChanged(_ call: Call!, args: PropertyChangedEventArgs!)
+}
+
+
+/**
+ * A set of methods that are called by ACSRemoteParticipant in response to important events.
+ */
+public protocol RemoteParticipantDelegate : NSObjectProtocol {
+
+    
+    optional func onStateChanged(_ remoteParticipant: RemoteParticipant!, args: PropertyChangedEventArgs!)
+
+    optional func onIsMutedChanged(_ remoteParticipant: RemoteParticipant!, args: PropertyChangedEventArgs!)
+
+    optional func onIsSpeakingChanged(_ remoteParticipant: RemoteParticipant!, args: PropertyChangedEventArgs!)
+
+    optional func onDisplayNameChanged(_ remoteParticipant: RemoteParticipant!, args: PropertyChangedEventArgs!)
+
+    optional func onVideoStreamsUpdated(_ remoteParticipant: RemoteParticipant!, args: RemoteVideoStreamsEventArgs!)
+}
+
+
+/**
+ * A set of methods that are called by ACSIncomingCall in response to important events.
+ */
+public protocol IncomingCallDelegate : NSObjectProtocol {
+
+    
+    optional func onCallEnded(_ incomingCall: IncomingCall!, args: PropertyChangedEventArgs!)
+}
+
+
+/**
+ * A set of methods that are called by ACSDeviceManager in response to important events.
+ */
+public protocol DeviceManagerDelegate : NSObjectProtocol {
+
+    
+    optional func onMicrophonesUpdated(_ deviceManager: DeviceManager!, args: AudioDevicesUpdatedEventArgs!)
+
+    optional func onSpeakersUpdated(_ deviceManager: DeviceManager!, args: AudioDevicesUpdatedEventArgs!)
+
+    optional func onCamerasUpdated(_ deviceManager: DeviceManager!, args: VideoDevicesUpdatedEventArgs!)
+}
+
+
+/// Property bag class for Video Options. Use this class to set video options required during a call (start/accept/join)
+open class VideoOptions : NSObject {
+
+    public init!(localVideoStream: LocalVideoStream!)
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// The video stream that is used to render the video on the UI surface
+    open var localVideoStream: LocalVideoStream!
+}
+
+
+/// Local video stream information
+open class LocalVideoStream : NSObject {
+
+    public init!(camera: VideoDeviceInfo!)
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Video device to use as source for local video.
+    open var source: VideoDeviceInfo! { get }
+
+    
+    /// Sets to True when the local video stream is being sent on a call.
+    open var isSending: Bool { get }
+
+    
+    /// Video stream type being used for the current stream.
+    open var mediaStreamType: MediaStreamType { get }
+
+    
+    // Class extension begins for LocalVideoStream.
+    open func switchSource(camera: VideoDeviceInfo!, completionHandler: ((Error?) -> Void)!)
+}
+
+// Class extension ends for LocalVideoStream.
+
+
+/// Information about a video device
+open class VideoDeviceInfo : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Get the name of this video device.
+    open var name: String! { get }
+
+    
+    /// Get Name of this audio device.
+    open var id: String! { get }
+
+    
+    /// Direction of the camera
+    open var cameraFacing: CameraFacing { get }
+
+    
+    /// Get the Device Type of this video device.
+    open var deviceType: VideoDeviceType { get }
+}
+
+
+/// Internal Use Only. Should not be used publicly. Will be removed in the future.
+open class InternalTokenProvider : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /**
+     * The delegate that will handle events from the ACSInternalTokenProvider.
+     */
+    unowned(unsafe) open var delegate: InternalTokenProviderDelegate!
+
+    
+    /// Exclusively for Internal. Do not use publicly. Will be removed in the future.
+    open func set(with token: String!, accountIdentity: String!, displayName: String!, resourceId: String!)
+
+    
+    /// Exclusively for Internal. Do not use publicly. Will be removed in the future.
+    open func set(error: String!)
+}
+
+
+/// Property bag class for Audio Options. Use this class to set audio settings required during a call (start/join)
+open class AudioOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Start an outgoing or accept incoming call muted (true) or un-muted(false)
+    open var muted: Bool
+}
+
+
+/// Options to be passed when joining a call
+open class JoinCallOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Video options when placing a call
+    open var videoOptions: VideoOptions!
+
+    
+    /// Audio options when placing a call
+    open var audioOptions: AudioOptions!
+}
+
+
+/// Options to be passed when accepting a call
+open class AcceptCallOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Video options when accepting a call
+    open var videoOptions: VideoOptions!
+}
+
+
+/// Options to be passed when starting a call
+open class StartCallOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Video options when starting a call
+    open var videoOptions: VideoOptions!
+
+    
+    /// Audio options when starting a call
+    open var audioOptions: AudioOptions!
+
+    
+    // Class extension begins for StartCallOptions.
+    open var alternateCallerID: PhoneNumberIdentifier
+}
+
+// Class extension ends for StartCallOptions.
+
+
+/// Options when making an outgoing PSTN call
+open class AddPhoneNumberOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    // Class extension begins for AddPhoneNumberOptions.
+    open var alternateCallerID: PhoneNumberIdentifier
+}
+
+// Class extension ends for AddPhoneNumberOptions.
+
+open class AbstractJoinMeetingLocator : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+}
+
+
+/// Options for joining a group call
+open class GroupCallLocator : AbstractJoinMeetingLocator {
+
+    public init!(groupId: UUID!)
+
+    
+    /// The unique identifier for the group conversation
+    open var groupId: UUID!
+}
+
+open class TeamsMeetingCoordinatesLocator : AbstractJoinMeetingLocator {
+
+    public init!(with threadId: String!, organizerId: UUID!, tenantId: UUID!, messageId: String!)
+
+    
+    /// The thread identifier of meeting
+    open var threadId: String! { get }
+
+    
+    /// The organizer identifier of meeting
+    open var organizerId: UUID!
+
+    
+    /// The tenant identifier of meeting
+    open var tenantId: UUID!
+
+    
+    /// The message identifier of meeting
+    open var messageId: String! { get }
+}
+
+open class TeamsMeetingLinkLocator : AbstractJoinMeetingLocator {
+
+    public init!(meetingLink: String!)
+
+    
+    /// The link of the meeting
+    open var meetingLink: String! { get }
+}
+
+open class IncomingCallInformation : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    open var fromDisplayName: String! { get }
+
+    
+    open var hasIncomingVideo: Bool { get }
+
+    
+    // Class extension begins for IncomingCallInformation.
+    open var from: CommunicationIdentifier! { get }
+
+    open var to: CommunicationIdentifier! { get }
+
+    open var callId: UUID { get }
+
+    open class func from(payload: [AnyHashable : Any]!) -> IncomingCallInformation!
+}
+
+// Class extension ends for IncomingCallInformation.
+
+
+/// Options for creating CallAgent
+open class CallAgentOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Specify the display name of the local participant for all new calls
+    open var displayName: String!
+}
+
+
+/// Call agent created by the CallClient factory method createCallAgent It bears the responsibility of managing calls on behalf of the authenticated user
+open class CallAgent : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Returns the list of all active calls.
+    open var calls: [Call]! { get }
+
+    
+    /**
+     * The delegate that will handle events from the ACSCallAgent.
+     */
+    unowned(unsafe) open var delegate: CallAgentDelegate!
+
+    
+    open func handlePush(notification: IncomingCallInformation!, completionHandler: ((Error?) -> Void)!)
+
+    
+    open func unRegisterPushNotifications(completionHandler: ((Error?) -> Void)!)
+
+    
+    // Class extension begins for CallAgent.
+    open func startCall(participants: [CommunicationIdentifier]!, options: StartCallOptions!) -> Call!
+
+    open func join(with meetingLocator: AbstractJoinMeetingLocator!, joinCallOptions: JoinCallOptions!) -> Call!
+
+    open func registerPushNotifications(deviceToken: Data!, completionHandler: ((Error?) -> Void)!)
+}
+
+// Class extension ends for CallAgent.
+
+
+/// Describes a call
+open class Call : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Get a list of remote participants in the current call.
+    open var remoteParticipants: [RemoteParticipant]! { get }
+
+    
+    /// Id of the call
+    open var id: String! { get }
+
+    
+    /// Current state of the call
+    open var state: CallState { get }
+
+    
+    /// Containing code/subcode indicating how a call has ended
+    open var callEndReason: CallEndReason! { get }
+
+    
+    /// Outgoing or Incoming depending on the Call Direction
+    open var callDirection: CallDirection { get }
+
+    
+    /// Whether the local microphone is muted or not.
+    open var isMicrophoneMuted: Bool { get }
+
+    
+    /// Get a list of local video streams in the current call.
+    open var localVideoStreams: [LocalVideoStream]! { get }
+
+    
+    /// Indicates if recording is active in current call
+    open var isRecordingActive: Bool { get }
+
+    
+    /**
+     * The delegate that will handle events from the ACSCall.
+     */
+    unowned(unsafe) open var delegate: CallDelegate!
+
+    
+    /// Mute local microphone.
+    open func mute(completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Unmute local microphone.
+    open func unmute(completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Send DTMF tone
+    open func sendDtmf(tone: DtmfTone, completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Start sharing video stream to the call
+    open func startVideo(stream: LocalVideoStream!, completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Stop sharing video stream to the call
+    open func stopVideo(stream: LocalVideoStream!, completionHandler: ((Error?) -> Void)!)
+
+    
+    /// HangUp a call
+    open func hangUp(options: HangUpOptions!, completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Remove a participant from a call
+    open func remove(participant: RemoteParticipant!, completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Hold this call
+    open func hold(completionHandler: ((Error?) -> Void)!)
+
+    
+    /// Resume this call
+    open func resume(completionHandler: ((Error?) -> Void)!)
+
+    
+    // Class extension begins for Call.
+    open var callerId: CommunicationIdentifier
+
+    open func add(participant: CommunicationIdentifier!) -> RemoteParticipant!
+
+    open func add(participant: PhoneNumberIdentifier!, options: AddPhoneNumberOptions!) -> RemoteParticipant!
+}
+
+// Class extension ends for Call.
+
+
+/// Describes a remote participant on a call
+open class RemoteParticipant : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Private Preview Only: Display Name of the remote participant
+    open var displayName: String! { get }
+
+    
+    /// True if the remote participant is muted
+    open var isMuted: Bool { get }
+
+    
+    /// True if the remote participant is speaking
+    open var isSpeaking: Bool { get }
+
+    
+    /// Reason why participant left the call, contains code/subcode.
+    open var callEndReason: CallEndReason! { get }
+
+    
+    /// Current state of the remote participant
+    open var state: ParticipantState { get }
+
+    
+    /// Remote Video streams part of the current call
+    open var videoStreams: [RemoteVideoStream]! { get }
+
+    
+    /**
+     * The delegate that will handle events from the ACSRemoteParticipant.
+     */
+    unowned(unsafe) open var delegate: RemoteParticipantDelegate!
+
+    
+    // Class extension begins for RemoteParticipant.
+    open var identity: CommunicationIdentifier
+}
+
+// Class extension ends for RemoteParticipant.
+
+
+/// Describes the reason for a call to end
+open class CallEndReason : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// The code
+    open var code: Int32 { get }
+
+    
+    /// The subcode
+    open var subcode: Int32 { get }
+}
+
+
+/// Video stream on remote participant (NOT SUPPORTED)
+open class RemoteVideoStream : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// True when remote video stream is available.
+    open var isAvailable: Bool { get }
+
+    
+    /// MediaStream type of the current remote video stream (Video or ScreenShare).
+    open var type: MediaStreamType { get }
+
+    
+    /// Unique Identifier of the current remote video stream.
+    open var id: Int32 { get }
+}
+
+
+/// Describes a PropertyChanged event data
+open class PropertyChangedEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+}
+
+
+/// Information about remote video streams added or removed (NOT SUPPORTED)
+open class RemoteVideoStreamsEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Remote video streams that have been added to the current call
+    open var addedRemoteVideoStreams: [RemoteVideoStream]! { get }
+
+    
+    /// Remote video streams that are no longer part of the current call
+    open var removedRemoteVideoStreams: [RemoteVideoStream]! { get }
+}
+
+
+/// Describes a ParticipantsUpdated event data
+open class ParticipantsUpdatedEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// List of Participants that were added
+    open var addedParticipants: [RemoteParticipant]! { get }
+
+    
+    /// List of Participants that were removed
+    open var removedParticipants: [RemoteParticipant]! { get }
+}
+
+
+/// Describes a LocalVideoStreamsUpdated event data
+open class LocalVideoStreamsUpdatedEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// List of LocalVideoStream that were added
+    open var addedStreams: [LocalVideoStream]! { get }
+
+    
+    /// List of LocalVideoStream that were removed
+    open var removedStreams: [LocalVideoStream]! { get }
+}
+
+
+/// Property bag class for hanging up a call
+open class HangUpOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Use to determine whether the current call should be terminated for all participant on the call or not
+    open var forEveryone: Bool
+}
+
+
+/// Describes a CallsUpdated event
+open class CallsUpdatedEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// New calls being tracked by the library
+    open var addedCalls: [Call]! { get }
+
+    
+    /// Calls that are no longer tracked by the library
+    open var removedCalls: [Call]! { get }
+}
+
+
+/// Describes the reason for a call to end
+open class IncomingCall : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    open var callerInfo: IncomingCallInformation! { get }
+
+    
+    open var callEndReason: CallEndReason! { get }
+
+    
+    /**
+     * The delegate that will handle events from the ACSIncomingCall.
+     */
+    unowned(unsafe) open var delegate: IncomingCallDelegate!
+
+    
+    /// Accept an incoming call
+    open func accept(options: AcceptCallOptions!, completionHandler: ((Call?, Error?) -> Void)!)
+
+    
+    /// Reject this incoming call
+    open func reject(completionHandler: ((Error?) -> Void)!)
+}
+
+
+/// Property bag class as container for SDK initialization options.
+open class InitializationOptions : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Path where logs should be saved on the disk
+    open var dataPath: String!
+
+    
+    /// Name of the log file
+    open var logFileName: String!
+
+    
+    /// Private Preview Only: Enable log encryption
+    open var isEncrypted: Bool
+
+    
+    /// Private Preview Only: Enable STDOUT logging. Disabled by default.
+    open var stdoutLogging: Bool
+}
+
+
+/// This is the main class representing the entrypoint for the Calling SDK.
+open class CallClient : NSObject {
+
+    public init!()
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Gets a device manager object that can be used to enumerates audio and video devices available for calls.
+    open func getDeviceManager(completionHandler: ((DeviceManager?, Error?) -> Void)!)
+
+    
+    // Class extension begins for CallClient.
+    open func createCallAgent(userCredential: CommunicationTokenCredential!, options callAgentOptions: CallAgentOptions!, completionHandler: ((CallAgent?, Error?) -> Void)!)
+
+    
+    open func createCallAgent(userCredential: CommunicationTokenCredential!, completionHandler: ((CallAgent?, Error?) -> Void)!)
+
+    
+    open var communicationCredential: CommunicationTokenCredential
+}
+
+// Class extension ends for CallClient.
+
+
+/// Device manager
+open class DeviceManager : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Gets the currently selected microphone
+    open var microphone: AudioDeviceInfo! { get }
+
+    
+    /// Gets the currently selected speaker
+    open var speaker: AudioDeviceInfo! { get }
+
+    
+    /// Get the list of currently connected video devices
+    open var cameras: [VideoDeviceInfo]! { get }
+
+    
+    /// Get the list of currently connected microphones
+    open var microphones: [AudioDeviceInfo]! { get }
+
+    
+    /// Get the list of currently connected speakers
+    open var speakers: [AudioDeviceInfo]! { get }
+
+    
+    /**
+     * The delegate that will handle events from the ACSDeviceManager.
+     */
+    unowned(unsafe) open var delegate: DeviceManagerDelegate!
+
+    
+    /// Set the microphone to be used for all active calls
+    open func setMicrophone(microphoneDevice: AudioDeviceInfo!)
+
+    
+    /// Set the speakers to be used for all active calls
+    open func setSpeaker(speakerDevice: AudioDeviceInfo!)
+}
+
+
+/// Information about an audio device
+open class AudioDeviceInfo : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Get the name of this audio device.
+    open var name: String! { get }
+
+    
+    /// Get Id of this audio device.
+    open var id: String! { get }
+
+    
+    /// True if device is a system default
+    open var isSystemDefault: Bool { get }
+
+    
+    /// Get the type of this audio device.
+    open var deviceType: AudioDeviceType { get }
+}
+
+
+/// Describes a AudioDevicesUpdated event data
+open class AudioDevicesUpdatedEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// List of AudioDevices that were added
+    open var addedAudioDevices: [AudioDeviceInfo]! { get }
+
+    
+    /// List of AudioDevices that were removed
+    open var removedAudioDevices: [AudioDeviceInfo]! { get }
+}
+
+
+/// Describes a VideoDevicesUpdated event data
+open class VideoDevicesUpdatedEventArgs : NSObject {
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Video devicesRemote video streams that have been added to the current call
+    open var addedVideoDevices: [VideoDeviceInfo]! { get }
+
+    
+    /// Remote video streams that have been added to the current call
+    open var removedVideoDevices: [VideoDeviceInfo]! { get }
+}
+
+
+/// Options to be passed when rendering a Video
+open class RenderingOptions : NSObject {
+
+    public init!(scalingMode: ScalingMode)
+
+    
+    /// Deallocates the memory occupied by this object.
+    open func dealloc()
+
+    
+    /// Scaling mode for rendering the video.
+    open var scalingMode: ScalingMode
+}


### PR DESCRIPTION
1. API samples written in Swift demonstrates how SDK will be used from a Swift application.
2. Swift 5 generated header files for the Objective-C public header files exposed in the framework.

**Missing features:**

1. Currently we are not setting nullability type specifier for properties and arguments to API's , we will be fixing those in the APIGen before GA.
2. Some API's in the SDK that are throwing we need to add `__attribute__((swift_error(nonnull_error)))` , currently those API's will make the application crash and there is no way for the Swift code to catch those exception. We will fix those as well before GA.

**Changes done since the previous review:**

1. Passing parameter labels to the API's are mandatory.
2. ACS prefix for all the classes, enums are dropped when used from Swift application.
3. default init where not applicable has been disabled with `NS_SWIFT_UNAVAILABLE`.
4. For events first parameter label is disabled and second is mandatory
   ` public func onCallEnded(_ incomingCall: IncomingCall!, args: PropertyChangedEventArgs!) `


