### PR TITLE
Update SmokeTest for use on CI

### DIFF
--- a/AzureCommunicationChat.podspec.json
+++ b/AzureCommunicationChat.podspec.json
@@ -27,6 +27,9 @@
   "dependencies": {
     "AzureCore": [
       "~> 1.0.0-beta.8"
+    ],
+    "AzureCommunication": [
+      "~> 1.0.0-beta.8"
     ]
   },
   "swift_version": "5.0"

--- a/AzureCommunicationChat.podspec.json
+++ b/AzureCommunicationChat.podspec.json
@@ -27,9 +27,6 @@
   "dependencies": {
     "AzureCore": [
       "~> 1.0.0-beta.8"
-    ],
-    "AzureCommunication": [
-      "~> 1.0.0-beta.8"
     ]
   },
   "swift_version": "5.0"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -247,49 +247,50 @@ jobs:
                      -configuration Debug | xcpretty -c
         displayName: 'Build examples [iphonesimulator]'
 
-#  - job: 'SmokeTest'
-#    strategy:
-#      matrix:
-#        # Build SDK libraries as frameworks, dynamically link to copies stored within the app bundle
-#        frameworks:
-#          PodsLinkage: frameworks
-#
-#        # Build SDK libraries as static libs (.a), statically link them into the app binary
-#        # This is currently broken, probably because Calling is pre-built as a framework
-#        # static:
-#        #   PodsLinkage: static
-#
-#        # Build SDK libraries as frameworks, but then statically link them into the app binary
-#        # Calling is still dynamically linked, probably because Calling is pre-built as a framework
-#        staticframeworks:
-#          PodsLinkage: staticframeworks
-#
-#    variables:
-#      - template: ../variables/globals.yml
-#
-#    pool:
-#      vmImage: '$(OSVmImage)'
-#
-#    steps:
-#      - script: sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app
-#        displayName: 'Use Xcode $(XcodeVersion)'
-#
-#      - script: |
-#          cd examples/AzureSDKSmokeTest
-#          pod install
-#        env:
-#          PODS_LINKAGE: $(PodsLinkage)
-#        displayName: 'Install dependencies'
-#
-#      - script: |
-#          set -o pipefail
-#          cd examples/AzureSDKSmokeTest
-#          xcodebuild build \
-#                     -workspace AzureSDKSmokeTest.xcworkspace \
-#                     -scheme AzureSDKSmokeTest \
-#                     -sdk iphonesimulator \
-#                     -configuration Debug | xcpretty -c
-#        displayName: 'Build smoke test [iphonesimulator]'
+  - job: 'SmokeTest'
+    strategy:
+      matrix:
+        # Build SDK libraries as frameworks, dynamically link to copies stored within the app bundle
+        frameworks:
+          PodsLinkage: frameworks
+
+        # Build SDK libraries as static libs (.a), statically link them into the app binary
+        # This is currently broken, probably because Calling is pre-built as a framework
+        # static:
+        #   PodsLinkage: static
+
+        # Build SDK libraries as frameworks, but then statically link them into the app binary
+        # Calling is still dynamically linked, probably because Calling is pre-built as a framework
+        staticframeworks:
+          PodsLinkage: staticframeworks
+
+    variables:
+      - template: ../variables/globals.yml
+
+    pool:
+      vmImage: '$(OSVmImage)'
+
+    steps:
+      - script: sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app
+        displayName: 'Use Xcode $(XcodeVersion)'
+
+      - script: |
+          cd examples/AzureSDKSmokeTest
+          pod install
+        env:
+          IS_CI: True
+          PODSPEC_DIR: $(Build.Repository.LocalPath)
+          PODS_LINKAGE: $(PodsLinkage)
+        displayName: 'Install dependencies'
+      - script: |
+          set -o pipefail
+          cd examples/AzureSDKSmokeTest
+          xcodebuild build \
+                     -workspace AzureSDKSmokeTest.xcworkspace \
+                     -scheme AzureSDKSmokeTest \
+                     -sdk iphonesimulator \
+                     -configuration Debug | xcpretty -c
+        displayName: 'Build smoke test [iphonesimulator]'
   - job: 'PodLint'
   
     variables:

--- a/examples/AzureSDKSmokeTest/AzureSDKSmokeTest.xcodeproj/project.pbxproj
+++ b/examples/AzureSDKSmokeTest/AzureSDKSmokeTest.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				INFOPLIST_FILE = AzureSDKSmokeTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -396,6 +397,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				INFOPLIST_FILE = AzureSDKSmokeTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/examples/AzureSDKSmokeTest/Podfile
+++ b/examples/AzureSDKSmokeTest/Podfile
@@ -27,6 +27,7 @@
 
 platform :ios, '13.0'
 
+# Determine linkage type
 if ENV['PODS_LINKAGE']&.downcase == 'static'
   puts 'Using Static Libraries'
 elsif ENV['PODS_LINKAGE']&.downcase == 'staticframeworks'
@@ -37,9 +38,22 @@ else
   use_frameworks!
 end
 
+# determine if running on CI or not and populate local directory
+is_ci = ENV.key?('IS_CI')
+local_path = ENV['PODSPEC_DIR']
+
 target 'AzureSDKSmokeTest' do
-  pod 'AzureCore', :git => 'https://github.com/Azure/azure-sdk-for-ios.git', :branch => 'VersionBeta8'
-  pod 'AzureCommunication', :git => 'https://github.com/Azure/azure-sdk-for-ios.git', :branch => 'VersionBeta8'
-  pod 'AzureCommunicationChat', :git => 'https://github.com/Azure/azure-sdk-for-ios.git', :branch => 'VersionBeta8'
-  pod 'AzureCommunicationCalling', :podspec => 'https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/VersionBeta8/AzureCommunicationCalling.podspec.json'
+  if is_ci
+    # install podspecs locally from source branch/PR
+    pod 'AzureCore', :podspec => "#{local_path}/AzureCore.podspec.json"
+    pod 'AzureCommunication', :podspec => "#{local_path}/AzureCommunication.podspec.json"
+    pod 'AzureCommunicationChat', :podspec => "#{local_path}/AzureCommunicationChat.podspec.json"
+    pod 'AzureCommunicationCalling', :podspec => "#{local_path}/AzureCommunicationCalling.podspec.json"
+  else
+    # manual run targets AzureSDK master branch
+    pod 'AzureCore', :git => 'https://github.com/Azure/azure-sdk-for-ios.git', :branch => 'master'
+    pod 'AzureCommunication', :git => 'https://github.com/Azure/azure-sdk-for-ios.git', :branch => 'master'
+    pod 'AzureCommunicationChat', :git => 'https://github.com/Azure/azure-sdk-for-ios.git', :branch => 'master'
+    pod 'AzureCommunicationCalling', :podspec => 'https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/master/AzureCommunicationCalling.podspec.json'
+  end
 end


### PR DESCRIPTION
Configures the SmokeTest to pull podspecs from the build branch. This should mean that changes which would break the build can be stopped before they are introduced rather than caught after the build has been broken.

Fixes #695.

Note that I'm note entirely sure this *should* run on PRs. My original intent was only to run it for releases. I can envision a scenario where, for example, `AzureCommunication` makes a breaking change and this check will fail until `AzureCommunicationCalling` updates their SDK accordingly. Thoughts?