### PR TITLE
Update Signalling 

### DIFF
--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
@@ -14,6 +14,11 @@
 		D10458A925EEA47800B3EB6D /* TrouterNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A325EEA47800B3EB6D /* TrouterNotificationPayload.swift */; };
 		D10458AA25EEA47800B3EB6D /* TrouterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A425EEA47800B3EB6D /* TrouterSettings.swift */; };
 		D10458AB25EEA47800B3EB6D /* chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A625EEA47800B3EB6D /* chat.swift */; };
+		D10458D025EEA54700B3EB6D /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D10458CF25EEA54700B3EB6D /* CoreTelephony.framework */; };
+		D10458D225EEA55400B3EB6D /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D10458D125EEA55400B3EB6D /* libc++.tbd */; };
+		D10458D725EEA57400B3EB6D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D10458D625EEA57400B3EB6D /* libz.tbd */; };
+		D10458DC25EEA57E00B3EB6D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D10458DB25EEA57E00B3EB6D /* SystemConfiguration.framework */; };
+		D10458DE25EEA5CB00B3EB6D /* libtrouter-client-ios-x64.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D10458DD25EEA5CB00B3EB6D /* libtrouter-client-ios-x64.a */; };
 		D10C3BCE25A63F7800A181E3 /* listParticipants.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BCD25A63F7800A181E3 /* listParticipants.json */; };
 		D10C3BD425A660AF00A181E3 /* listMessages.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BD325A660AF00A181E3 /* listMessages.json */; };
 		D10C3BDA25A66D4D00A181E3 /* listThreads.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BD925A66D4D00A181E3 /* listThreads.json */; };
@@ -158,6 +163,11 @@
 		D10458A325EEA47800B3EB6D /* TrouterNotificationPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrouterNotificationPayload.swift; sourceTree = "<group>"; };
 		D10458A425EEA47800B3EB6D /* TrouterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrouterSettings.swift; sourceTree = "<group>"; };
 		D10458A625EEA47800B3EB6D /* chat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = chat.swift; sourceTree = "<group>"; };
+		D10458CF25EEA54700B3EB6D /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/CoreTelephony.framework; sourceTree = DEVELOPER_DIR; };
+		D10458D125EEA55400B3EB6D /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/lib/libc++.tbd"; sourceTree = DEVELOPER_DIR; };
+		D10458D625EEA57400B3EB6D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
+		D10458DB25EEA57E00B3EB6D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		D10458DD25EEA5CB00B3EB6D /* libtrouter-client-ios-x64.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libtrouter-client-ios-x64.a"; path = "../../../../Trouter/TrouterClientiOS/Lib/libtrouter-client-ios-x64.a"; sourceTree = "<group>"; };
 		D10C3BCD25A63F7800A181E3 /* listParticipants.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listParticipants.json; sourceTree = "<group>"; };
 		D10C3BD325A660AF00A181E3 /* listMessages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listMessages.json; sourceTree = "<group>"; };
 		D10C3BD925A66D4D00A181E3 /* listThreads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listThreads.json; sourceTree = "<group>"; };
@@ -269,6 +279,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				D10458DE25EEA5CB00B3EB6D /* libtrouter-client-ios-x64.a in Frameworks */,
+				D10458DC25EEA57E00B3EB6D /* SystemConfiguration.framework in Frameworks */,
+				D10458D725EEA57400B3EB6D /* libz.tbd in Frameworks */,
+				D10458D225EEA55400B3EB6D /* libc++.tbd in Frameworks */,
+				D10458D025EEA54700B3EB6D /* CoreTelephony.framework in Frameworks */,
 				D110F50A258D604B001FA3CD /* AzureCore.framework in Frameworks */,
 				D110F507258D603F001FA3CD /* AzureCommunication.framework in Frameworks */,
 				D110F50C258D6053001FA3CD /* Pods_AzureCommunicationChat.framework in Frameworks */,
@@ -289,6 +304,11 @@
 		0A74765A2522918800819FC9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D10458DD25EEA5CB00B3EB6D /* libtrouter-client-ios-x64.a */,
+				D10458DB25EEA57E00B3EB6D /* SystemConfiguration.framework */,
+				D10458D625EEA57400B3EB6D /* libz.tbd */,
+				D10458D125EEA55400B3EB6D /* libc++.tbd */,
+				D10458CF25EEA54700B3EB6D /* CoreTelephony.framework */,
 				D110F50B258D6053001FA3CD /* Pods_AzureCommunicationChat.framework */,
 				D110F509258D604B001FA3CD /* AzureCore.framework */,
 				D110F506258D603F001FA3CD /* AzureCommunication.framework */,

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
@@ -9,6 +9,11 @@
 /* Begin PBXBuildFile section */
 		4077D21553368B726C02EA20 /* Pods_AzureCommunicationChatUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FD7709F18BED14D6B73C734 /* Pods_AzureCommunicationChatUnitTests.framework */; };
 		9766BE9261FCB48436FA6682 /* Pods_AzureCommunicationChatTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1FE3013E797A134E8A6C3B5 /* Pods_AzureCommunicationChatTests.framework */; };
+		D10458A725EEA47800B3EB6D /* CommunicationSignallingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A125EEA47800B3EB6D /* CommunicationSignallingClient.swift */; };
+		D10458A825EEA47800B3EB6D /* TrouterUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A225EEA47800B3EB6D /* TrouterUtils.swift */; };
+		D10458A925EEA47800B3EB6D /* TrouterNotificationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A325EEA47800B3EB6D /* TrouterNotificationPayload.swift */; };
+		D10458AA25EEA47800B3EB6D /* TrouterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A425EEA47800B3EB6D /* TrouterSettings.swift */; };
+		D10458AB25EEA47800B3EB6D /* chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A625EEA47800B3EB6D /* chat.swift */; };
 		D10C3BCE25A63F7800A181E3 /* listParticipants.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BCD25A63F7800A181E3 /* listParticipants.json */; };
 		D10C3BD425A660AF00A181E3 /* listMessages.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BD325A660AF00A181E3 /* listMessages.json */; };
 		D10C3BDA25A66D4D00A181E3 /* listThreads.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BD925A66D4D00A181E3 /* listThreads.json */; };
@@ -143,6 +148,16 @@
 		8E5206D2E09378DA0F9FD0E4 /* Pods-AzureCommunicationChatTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureCommunicationChatTests.release.xcconfig"; path = "Target Support Files/Pods-AzureCommunicationChatTests/Pods-AzureCommunicationChatTests.release.xcconfig"; sourceTree = "<group>"; };
 		9FE998BEC9685C476F2AFD1C /* Pods-AzureCommunicationChat.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureCommunicationChat.debug.xcconfig"; path = "Target Support Files/Pods-AzureCommunicationChat/Pods-AzureCommunicationChat.debug.xcconfig"; sourceTree = "<group>"; };
 		"AzureCommunicationChat::AzureCommunicationChat::Product" /* AzureCommunicationChat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCommunicationChat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D104589B25EEA47800B3EB6D /* TrouterUrlRegistrar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrouterUrlRegistrar.h; sourceTree = "<group>"; };
+		D104589C25EEA47800B3EB6D /* Trouter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Trouter.h; sourceTree = "<group>"; };
+		D104589D25EEA47800B3EB6D /* SelfHostedTrouterClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SelfHostedTrouterClient.h; sourceTree = "<group>"; };
+		D104589E25EEA47800B3EB6D /* TrouterSkypetokenProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrouterSkypetokenProvider.h; sourceTree = "<group>"; };
+		D10458A025EEA47800B3EB6D /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		D10458A125EEA47800B3EB6D /* CommunicationSignallingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommunicationSignallingClient.swift; sourceTree = "<group>"; };
+		D10458A225EEA47800B3EB6D /* TrouterUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrouterUtils.swift; sourceTree = "<group>"; };
+		D10458A325EEA47800B3EB6D /* TrouterNotificationPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrouterNotificationPayload.swift; sourceTree = "<group>"; };
+		D10458A425EEA47800B3EB6D /* TrouterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrouterSettings.swift; sourceTree = "<group>"; };
+		D10458A625EEA47800B3EB6D /* chat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = chat.swift; sourceTree = "<group>"; };
 		D10C3BCD25A63F7800A181E3 /* listParticipants.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listParticipants.json; sourceTree = "<group>"; };
 		D10C3BD325A660AF00A181E3 /* listMessages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listMessages.json; sourceTree = "<group>"; };
 		D10C3BD925A66D4D00A181E3 /* listThreads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listThreads.json; sourceTree = "<group>"; };
@@ -315,6 +330,47 @@
 			path = ../../../Pods;
 			sourceTree = "<group>";
 		};
+		D104589925EEA47800B3EB6D /* Signalling */ = {
+			isa = PBXGroup;
+			children = (
+				D104589A25EEA47800B3EB6D /* TrouterHeaderFiles */,
+				D104589F25EEA47800B3EB6D /* TrouterModulesPrivate */,
+				D10458A125EEA47800B3EB6D /* CommunicationSignallingClient.swift */,
+				D10458A225EEA47800B3EB6D /* TrouterUtils.swift */,
+				D10458A325EEA47800B3EB6D /* TrouterNotificationPayload.swift */,
+				D10458A425EEA47800B3EB6D /* TrouterSettings.swift */,
+				D10458A525EEA47800B3EB6D /* events */,
+			);
+			path = Signalling;
+			sourceTree = "<group>";
+		};
+		D104589A25EEA47800B3EB6D /* TrouterHeaderFiles */ = {
+			isa = PBXGroup;
+			children = (
+				D104589B25EEA47800B3EB6D /* TrouterUrlRegistrar.h */,
+				D104589C25EEA47800B3EB6D /* Trouter.h */,
+				D104589D25EEA47800B3EB6D /* SelfHostedTrouterClient.h */,
+				D104589E25EEA47800B3EB6D /* TrouterSkypetokenProvider.h */,
+			);
+			path = TrouterHeaderFiles;
+			sourceTree = "<group>";
+		};
+		D104589F25EEA47800B3EB6D /* TrouterModulesPrivate */ = {
+			isa = PBXGroup;
+			children = (
+				D10458A025EEA47800B3EB6D /* module.modulemap */,
+			);
+			path = TrouterModulesPrivate;
+			sourceTree = "<group>";
+		};
+		D10458A525EEA47800B3EB6D /* events */ = {
+			isa = PBXGroup;
+			children = (
+				D10458A625EEA47800B3EB6D /* chat.swift */,
+			);
+			path = events;
+			sourceTree = "<group>";
+		};
 		D15E98C925B7C80C00E63DB2 /* Generated */ = {
 			isa = PBXGroup;
 			children = (
@@ -480,6 +536,7 @@
 				D1565C70256DB74900AF45F8 /* ChatClient.swift */,
 				D1565C73256DB76C00AF45F8 /* ChatThreadClient.swift */,
 				D16C802B25BA0A0F00C42803 /* Models */,
+				D104589925EEA47800B3EB6D /* Signalling */,
 				D15E98C925B7C80C00E63DB2 /* Generated */,
 				0A10411225D306B3008E472E /* Supporting Files */,
 			);
@@ -788,6 +845,8 @@
 			files = (
 				D1565C71256DB74900AF45F8 /* ChatClient.swift in Sources */,
 				D1565C74256DB76C00AF45F8 /* ChatThreadClient.swift in Sources */,
+				D10458A725EEA47800B3EB6D /* CommunicationSignallingClient.swift in Sources */,
+				D10458A825EEA47800B3EB6D /* TrouterUtils.swift in Sources */,
 				D15E990525B7C80C00E63DB2 /* Chat+CreateChatThreadOptions.swift in Sources */,
 				D15E991925B7C80C00E63DB2 /* Enumerations.swift in Sources */,
 				D15E990F25B7C80C00E63DB2 /* CommunicationError.swift in Sources */,
@@ -805,6 +864,7 @@
 				D15E991225B7C80C00E63DB2 /* UpdateChatThreadRequest.swift in Sources */,
 				D15E991525B7C80C00E63DB2 /* CreateChatThreadErrors.swift in Sources */,
 				D15E990225B7C80C00E63DB2 /* ChatThreadOperation+SendChatReadReceiptOptions.swift in Sources */,
+				D10458AB25EEA47800B3EB6D /* chat.swift in Sources */,
 				D15E991A25B7C80C00E63DB2 /* AddChatParticipantsResult.swift in Sources */,
 				D15E991E25B7C80C00E63DB2 /* UpdateChatMessageRequest.swift in Sources */,
 				D15E991625B7C80C00E63DB2 /* ChatMessageReadReceipt.swift in Sources */,
@@ -822,6 +882,7 @@
 				D15E991C25B7C80C00E63DB2 /* ChatThreadsInfoCollection.swift in Sources */,
 				D15E98FA25B7C80C00E63DB2 /* AzureCommunicationChatClient.swift in Sources */,
 				D15E98FC25B7C80C00E63DB2 /* ChatThreadOperation+ListChatReadReceiptsOptions.swift in Sources */,
+				D10458AA25EEA47800B3EB6D /* TrouterSettings.swift in Sources */,
 				D15E992125B7C80C00E63DB2 /* ChatThreadInfo.swift in Sources */,
 				D15E991425B7C80C00E63DB2 /* ChatMessagesCollection.swift in Sources */,
 				D15E990D25B7C80C00E63DB2 /* Chat.swift in Sources */,
@@ -829,6 +890,7 @@
 				D15E990125B7C80C00E63DB2 /* ChatThreadOperation+SendChatMessageOptions.swift in Sources */,
 				D15E98FD25B7C80C00E63DB2 /* ChatThreadOperation+UpdateChatMessageOptions.swift in Sources */,
 				D15E991F25B7C80C00E63DB2 /* CreateChatThreadResult.swift in Sources */,
+				D10458A925EEA47800B3EB6D /* TrouterNotificationPayload.swift in Sources */,
 				D15E990B25B7C80C00E63DB2 /* ChatThreadOperation+ListChatParticipantsOptions.swift in Sources */,
 				D15E992525B7C80C00E63DB2 /* ChatParticipantsCollection.swift in Sources */,
 				D15E992025B7C80C00E63DB2 /* SendReadReceiptRequest.swift in Sources */,

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
@@ -1054,6 +1054,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/TrouterHeaderFiles";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1062,11 +1063,13 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = /Users/kinovose/Documents/Trouter/TrouterClientiOS/Lib;
 				MARKETING_VERSION = "1.0.0-beta.8";
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationChat;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Source/Signalling/TrouterModulesPrivate";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1084,6 +1087,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/TrouterHeaderFiles";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1092,11 +1096,13 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = /Users/kinovose/Documents/Trouter/TrouterClientiOS/Lib;
 				MARKETING_VERSION = "1.0.0-beta.8";
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationChat;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Source/Signalling/TrouterModulesPrivate";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
@@ -36,7 +36,7 @@ public class ChatClient {
     private let options: AzureCommunicationChatClientOptions
     private let service: Chat
     private let signallingClient: CommunicationSignallingClient?
-    private let isRealtimeNotificationsStarted: Bool = false
+    private var isRealtimeNotificationsStarted: Bool = false
 
     // MARK: Initializers
 
@@ -71,7 +71,7 @@ public class ChatClient {
 
         // Initialize the signalling client with the users access token
         var token: String?
-        credential.token { accessToken, error in
+        credential.token { accessToken, _ in
             token = accessToken?.token
         }
 
@@ -196,5 +196,51 @@ public class ChatClient {
                 completionHandler(.failure(error), httpResponse)
             }
         }
+    }
+
+    /// Start receiving realtime notifications.
+    /// Call this function before subscribing to any event.
+    public func startRealTimeNotifications() throws {
+        if signallingClient == nil {
+            throw AzureError.client("Signalling client is not initialized.")
+        }
+
+        if isRealtimeNotificationsStarted {
+            return
+        }
+
+        isRealtimeNotificationsStarted = true
+        signallingClient?.start()
+    }
+
+    /// Stop receiving realtime notifications.
+    /// This function would unsubscribe to all events.
+    public func stopRealTimeNotifications() throws {
+        if signallingClient == nil {
+            throw AzureError.client("Signalling client is not initialized.")
+        }
+
+        isRealtimeNotificationsStarted = false
+        signallingClient?.stop()
+    }
+
+    /// Subscribe to chat events
+    public func on(event: String, listener: @escaping EventListener) {
+        guard let _ = ChatEventId(rawValue: event) else {
+            options.logger.error("the event id provided is not supported")
+            return
+        }
+
+        signallingClient?.on(event: event, listener: listener)
+    }
+
+    /// Unsubscribe to chat events
+    public func off(event: String, listener: @escaping EventListener) {
+        guard let _ = ChatEventId(rawValue: event) else {
+            options.logger.error("the event id provided is not supported")
+            return
+        }
+
+        signallingClient?.off(event: event, listener: listener)
     }
 }

--- a/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
@@ -35,6 +35,8 @@ public class ChatClient {
     private let credential: CommunicationTokenCredential
     private let options: AzureCommunicationChatClientOptions
     private let service: Chat
+    private let signallingClient: CommunicationSignallingClient?
+    private let isRealtimeNotificationsStarted: Bool = false
 
     // MARK: Initializers
 
@@ -66,6 +68,29 @@ public class ChatClient {
         )
 
         self.service = client.chat
+
+        self.signallingClient = getSignallingClient(credential: credential)
+    }
+
+    // MARK: Private Methods
+
+    private func getSignallingClient(credential: CommunicationTokenCredential) -> CommunicationSignallingClient? {
+        var token: String?
+
+        credential.token(completionHandler: { communicationAccessToken, _
+            in
+            if let unwrapped = communicationAccessToken {
+                token = unwrapped.token
+            }
+        })
+
+        if let unwrapped = token {
+            return CommunicationSignallingClient(
+                skypeTokenProvider: CommunicationSkypeTokenProvider(skypeToken: unwrapped)
+            )
+        } else {
+            return nil
+        }
     }
 
     // MARK: Public Methods

--- a/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
@@ -69,28 +69,13 @@ public class ChatClient {
 
         self.service = client.chat
 
-        self.signallingClient = getSignallingClient(credential: credential)
-    }
-
-    // MARK: Private Methods
-
-    private func getSignallingClient(credential: CommunicationTokenCredential) -> CommunicationSignallingClient? {
+        // Initialize the signalling client with the users access token
         var token: String?
-
-        credential.token(completionHandler: { communicationAccessToken, _
-            in
-            if let unwrapped = communicationAccessToken {
-                token = unwrapped.token
-            }
-        })
-
-        if let unwrapped = token {
-            return CommunicationSignallingClient(
-                skypeTokenProvider: CommunicationSkypeTokenProvider(skypeToken: unwrapped)
-            )
-        } else {
-            return nil
+        credential.token { accessToken, error in
+            token = accessToken?.token
         }
+
+        self.signallingClient = CommunicationSignallingClient(token: token)
     }
 
     // MARK: Public Methods

--- a/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
@@ -224,23 +224,25 @@ public class ChatClient {
         signallingClient?.stop()
     }
 
-    /// Subscribe to chat events
-    public func on(event: String, listener: @escaping EventListener) {
-        guard let _ = ChatEventId(rawValue: event) else {
-            options.logger.error("the event id provided is not supported")
-            return
-        }
-
-        signallingClient?.on(event: event, listener: listener)
+    /// Subscribe to chat events.
+    /// - Parameters:
+    ///   - event: The chat event to subsribe to.
+    ///   - listener: The listener for the chat event.
+    public func on(
+        event: ChatEventId,
+        listener: @escaping EventListener
+    ) {
+        signallingClient?.on(event: event.rawValue, listener: listener)
     }
 
-    /// Unsubscribe to chat events
-    public func off(event: String, listener: @escaping EventListener) {
-        guard let _ = ChatEventId(rawValue: event) else {
-            options.logger.error("the event id provided is not supported")
-            return
-        }
-
-        signallingClient?.off(event: event, listener: listener)
+    /// Unsubscribe to chat events.
+    /// - Parameters:
+    ///   - event: The chat event to subsribe to.
+    ///   - listener: The listener for the chat event.
+    public func off(
+        event: ChatEventId,
+        listener: @escaping EventListener
+    ) {
+        signallingClient?.off(event: event.rawValue, listener: listener)
     }
 }

--- a/sdk/communication/AzureCommunicationChat/Source/Generated/Chat.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Generated/Chat.swift
@@ -55,7 +55,7 @@ public final class Chat {
         }
         let urlTemplate = "/chat/threads"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
+              let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -185,7 +185,7 @@ public final class Chat {
         // Construct request
         let urlTemplate = "/chat/threads"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -328,7 +328,7 @@ public final class Chat {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -459,7 +459,7 @@ public final class Chat {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .delete, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .delete, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return

--- a/sdk/communication/AzureCommunicationChat/Source/Generated/ChatThreadOperation.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Generated/ChatThreadOperation.swift
@@ -48,7 +48,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/readReceipts"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -198,7 +198,7 @@ public final class ChatThreadOperation {
         }
         let urlTemplate = "/chat/threads/{chatThreadId}/readReceipts"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
+              let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -331,7 +331,7 @@ public final class ChatThreadOperation {
         }
         let urlTemplate = "/chat/threads/{chatThreadId}/messages"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
+              let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -463,7 +463,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/messages"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -608,7 +608,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/messages/{chatMessageId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -748,12 +748,12 @@ public final class ChatThreadOperation {
         }
         let urlTemplate = "/chat/threads/{chatThreadId}/messages/{chatMessageId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(
-                method: .patch,
-                url: requestUrl,
-                headers: params.headers,
-                data: requestBody
-            )
+              let request = try? HTTPRequest(
+                  method: .patch,
+                  url: requestUrl,
+                  headers: params.headers,
+                  data: requestBody
+              )
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -881,7 +881,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/messages/{chatMessageId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .delete, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .delete, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -1007,7 +1007,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/typing"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -1134,7 +1134,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/participants"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .get, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -1279,7 +1279,7 @@ public final class ChatThreadOperation {
         // Construct request
         let urlTemplate = "/chat/threads/{chatThreadId}/participants/{chatParticipantId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .delete, url: requestUrl, headers: params.headers)
+              let request = try? HTTPRequest(method: .delete, url: requestUrl, headers: params.headers)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -1412,7 +1412,7 @@ public final class ChatThreadOperation {
         }
         let urlTemplate = "/chat/threads/{chatThreadId}/participants/:add"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
+              let request = try? HTTPRequest(method: .post, url: requestUrl, headers: params.headers, data: requestBody)
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return
@@ -1550,12 +1550,12 @@ public final class ChatThreadOperation {
         }
         let urlTemplate = "/chat/threads/{chatThreadId}"
         guard let requestUrl = client.url(host: "{endpoint}", template: urlTemplate, params: params),
-            let request = try? HTTPRequest(
-                method: .patch,
-                url: requestUrl,
-                headers: params.headers,
-                data: requestBody
-            )
+              let request = try? HTTPRequest(
+                  method: .patch,
+                  url: requestUrl,
+                  headers: params.headers,
+                  data: requestBody
+              )
         else {
             client.options.logger.error("Failed to construct HTTP request.")
             return

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
@@ -1,0 +1,168 @@
+//
+//  CommunicationSignalingClient.swift
+//  AzureCommunicationSignaling
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AzureCore
+import Foundation
+import TrouterModulePrivate
+import UIKit
+
+public class CommunicationSignalingClient {
+    private var selfHostedTrouterClient: SelfHostedTrouterClient
+    private var communicationSkypeTokenProvider: CommunicationSkypeTokenProvider
+    private var trouterUrlRegistrar: TrouterUrlRegistrar
+    private var logger: ClientLogger
+    private var communicationListeners: Set<CommunicationListener> = []
+
+    public init(
+        skypeTokenProvider: CommunicationSkypeTokenProvider,
+        logger: ClientLogger = ClientLoggers.default(tag: "AzureCommunicationSignalingClient")
+    ) {
+        self.communicationSkypeTokenProvider = skypeTokenProvider
+        self.logger = logger
+        let trouterSkypeTokenHeaderProvider = TrouterSkypetokenAuthHeaderProvider(
+            skypetokenProvider: communicationSkypeTokenProvider
+        )
+
+        let communicationCache = CommunicationCache()
+        selfHostedTrouterClient = SelfHostedTrouterClient.create(
+            withClientVersion: getClientVersion(),
+            authHeadersProvider: trouterSkypeTokenHeaderProvider,
+            dataCache: communicationCache,
+            trouterHostname: getTrouterHostname()
+        )
+
+        let regData: TrouterUrlRegistrationData = createRegistrationData()
+        // swiftlint:disable force_cast
+        trouterUrlRegistrar = TrouterUrlRegistrar.create(
+            with: communicationSkypeTokenProvider,
+            registrationData: regData,
+            registrarHostnameAndBasePath: getRegistrarHostnameAndBasePath(),
+            maxRegistrationTtlS: 3600
+        ) as! TrouterUrlRegistrar
+        // swiftlint:enable force_cast
+    }
+
+    public func start() {
+        selfHostedTrouterClient.withRegistrar(trouterUrlRegistrar)
+        selfHostedTrouterClient.start()
+    }
+
+    public func stop() {
+        selfHostedTrouterClient.stop()
+    }
+
+    public func on(event: String, listener: @escaping EventListener) {
+        let communicationListener = CommunicationListener(listener: listener)
+        switch event {
+        case ChatEventId.chatMessageReceived.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/chatMessageReceived")
+        case ChatEventId.typingIndicatorReceived.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/typingIndicatorReceived")
+        case ChatEventId.readReceiptReceived.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/readReceiptReceived")
+        case ChatEventId.chatMessageEdited.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/chatMessageEdited")
+        case ChatEventId.chatMessageDeleted.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/chatMessageDeleted")
+        case ChatEventId.chatThreadCreated.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/chatThreadCreated")
+        case ChatEventId.chatThreadPropertiesUpdated.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/chatThreadPropertiesUpdated")
+        case ChatEventId.chatThreadDeleted.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/chatThreadDeleted")
+        case ChatEventId.participantsAdded.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/participantsAdded")
+        case ChatEventId.participantsRemoved.rawValue:
+            selfHostedTrouterClient.register(communicationListener, forPath: "/participantsRemoved")
+        default:
+            return
+        }
+        communicationListeners.insert(communicationListener)
+    }
+
+    public func off(event _: String, listener: @escaping EventListener) {
+        let communicationListener = CommunicationListener(listener: listener)
+        if communicationListeners.contains(communicationListener) {
+            selfHostedTrouterClient.unregisterListener(communicationListener)
+            communicationListeners.remove(communicationListener)
+        }
+    }
+}
+
+public class CommunicationSkypeTokenProvider: NSObject, TrouterSkypetokenProvider {
+    var skypeToken: String?
+    public func getSkypetoken(_: Bool) -> String! {
+        return skypeToken
+    }
+
+    public init(skypeToken: String? = nil) {
+        self.skypeToken = skypeToken
+    }
+}
+
+class CommunicationCache: NSObject, TrouterConnectionDataCache {
+    var data: String?
+    func store(_ data: String!) {
+        self.data = data
+    }
+
+    func load() -> String! {
+        if data == nil {
+            data = ""
+        }
+        return data
+    }
+}
+
+class CommunicationListener: NSObject, TrouterListener {
+    var listener: EventListener
+    var logger: ClientLogger
+
+    init(
+        listener: @escaping EventListener,
+        logger: ClientLogger = ClientLoggers.default(tag: "AzureCommunicationListener")
+    ) {
+        self.listener = listener
+        self.logger = logger
+    }
+
+    func onTrouterConnected(_: String!, _: TrouterConnectionInfo!) {
+        logger.info("Trouter Connected")
+    }
+
+    func onTrouterDisconnected() {
+        logger.info("Trouter Disconnected")
+    }
+
+    func onTrouterRequest(_ request: TrouterRequest!, _ response: TrouterResponse!) {
+        logger.info("Received a Trouter request \n")
+
+        do {
+            let requestJsonData = request.body.data(using: .utf8)!
+            let generalPayload = try JSONDecoder().decode(BasePayload.self, from: requestJsonData)
+            guard let chatEventId = eventIds[generalPayload._eventId] else {
+                logger.error("event Id does not match with what are supported")
+                fatalError("event Id does not match with what are supported")
+            }
+            // convert trouter payload to chat event payload
+            let chatEvent = toEventPayload(request: request, chatEventId: chatEventId)
+            if let unwrapped = chatEvent {
+                listener(unwrapped, chatEventId)
+            }
+
+            response.body = "Request has been handled"
+            response.status = 200
+            let result: TrouterSendResponseResult = response.send()
+            logger.info("Sent a response to Trouter: \(result)")
+        } catch {
+            logger.error("Error: \(error)")
+        }
+    }
+}
+
+public typealias EventListener = (_ response: Any, _ eventId: ChatEventId) -> Void

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
@@ -157,9 +157,9 @@ class CommunicationListener: NSObject, TrouterListener {
             let requestJsonData = request.body.data(using: .utf8)!
             let generalPayload = try JSONDecoder().decode(BasePayload.self, from: requestJsonData)
             guard let chatEventId = eventIds[generalPayload._eventId] else {
-                logger.error("event Id does not match with what are supported")
-                fatalError("event Id does not match with what are supported")
+                throw AzureError.client("event Id does not match with what are supported")
             }
+
             // convert trouter payload to chat event payload
             let chatEvent = toEventPayload(request: request, chatEventId: chatEventId)
             if let unwrapped = chatEvent {

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
@@ -47,6 +47,17 @@ public class CommunicationSignallingClient {
         // swiftlint:enable force_cast
     }
 
+    public convenience init?(
+        token: String?
+    ) {
+        guard let skypeToken = token else {
+            return nil
+        }
+
+        let skypeTokenProvider = CommunicationSkypeTokenProvider(skypeToken: skypeToken)
+        self.init(skypeTokenProvider: skypeTokenProvider)
+    }
+
     public func start() {
         selfHostedTrouterClient.withRegistrar(trouterUrlRegistrar)
         selfHostedTrouterClient.start()

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/CommunicationSignallingClient.swift
@@ -11,7 +11,7 @@ import Foundation
 import TrouterModulePrivate
 import UIKit
 
-public class CommunicationSignalingClient {
+public class CommunicationSignallingClient {
     private var selfHostedTrouterClient: SelfHostedTrouterClient
     private var communicationSkypeTokenProvider: CommunicationSkypeTokenProvider
     private var trouterUrlRegistrar: TrouterUrlRegistrar

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/SelfHostedTrouterClient.h
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/SelfHostedTrouterClient.h
@@ -1,0 +1,64 @@
+#import "Trouter.h"
+#import "TrouterUrlRegistrar.h"
+#import "TrouterSkypetokenProvider.h"
+
+/**
+ * Represents a callback for trouter client to store and load connection data.
+ * Storing that data allows Trouter Client to reconnect to the service quicker
+ * and preserves Trouter URL.
+ *
+ * It can even be a simple in-memory storage for applications that start/stop
+ * Trouter client often during its lifetime
+ *
+ * !!! It is important to carefully separate data for applications with
+ *  multiple Trouter connections (e.g. multi user login)
+ */
+@protocol TrouterConnectionDataCache <NSObject>
+/**
+ * Called when trouter establishes new connection or is forced to reconnect to a new DC
+ */
+-(void)store:(NSString*)data;
+/**
+ * Called when trouter starts up and checks if it can reconnect instead of
+ * establishing brand new connection
+ */
+-(NSString*)load;
+@end
+
+/**
+ * This object represents self hosted Trouter Client
+ * i.e. client which lifecycle can be directly managed
+ * unlike trouter client hosted by SlimCore
+ */
+@interface SelfHostedTrouterClient : NSObject<TrouterClient>
+/**
+ * Creates new instance of self hosted trouter client
+ * It has to be started in order to establish connection to server
+ * Two phase startup is designed to let application register listeners prior to connecting
+ * @param authHeadersProvider is a must have dependency
+ * @param dataCache is an optional dependency which is recommended for maximum efficiency
+ * @param trouterHostname is an optional parameter pointing to one of the trouter service clouds (deployments)
+ *                   used to separate Consumer vs Enterprise traffic
+ *                   sample values are 'go.trouter.skype.com', 'go.trouter.teams.microsoft.com', 'go-us.trouter.teams.microsoft.com'
+ */
++ (SelfHostedTrouterClient*)createWithClientVersion:(NSString*)clientVersion
+                                authHeadersProvider:(id<TrouterAuthHeadersProvider>)authHeadersProvider
+                                          dataCache:(id<TrouterConnectionDataCache>)dataCache
+                                    trouterHostname:(NSString*)trouterHostname;
+/**
+ * Starts client connection to the Trouter service
+ */
+- (BOOL)start;
+/**
+  * Gracefully disconnects client from the service
+  * It does not reset listener registrations, those stay active
+  */
+- (BOOL)stop;
+/**
+ * Attaches registrar component that will track Trouter connection
+ * and automatically register it.
+ * Must be done before starting the client
+ */
+- (void)withRegistrar:(TrouterUrlRegistrar*)registrar;
+
+@end

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/Trouter.h
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/Trouter.h
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+
+/**
+ * Activity states that a user can be in on an endpoint
+ */
+typedef NS_ENUM(NSInteger, UserActivityState) {
+    //! Initial state
+    TrouterUserActivityStateUnknown       = 0,
+    //! User is active according to the application
+    TrouterUserActivityStateActive        = 1,
+    //! User is not active according to the application
+    TrouterUserActivityStateInactive      = 2
+};
+
+/**
+ * Possible return values of TrouterResponse.send()
+ */
+typedef NS_ENUM(NSUInteger, TrouterSendResponseResult) {
+    //! Response accepted, will be sent back to the service
+    TrouterSendResponseResultOK           = 0,
+    //! Too late, 504 (Timeout) has been already sent back
+    TrouterSendResponseResultTimeout      = 1,
+    //! send() was called multiple times on one Response
+    TrouterSendResponseResultDuplicate    = 2,
+    //! Mandatory parameters (status code) are not set
+    TrouterSendResponseResultIncomplete   = 3,
+    //! Trouter connection dropped, cannot reply now
+    TrouterSendResponseResultDisconnected = 4
+};
+
+/**
+ * Trouter HTTP-like request (service -> Trouter -> app)
+ *
+ * Represents one incoming request received by Trouter Client. Its content is
+ * mostly a verbatim copy of what was sent by the originating service to
+ * Trouter Service.
+ */
+@protocol TrouterRequest <NSObject>
+    //! Request/response ID, useful for logging/debugging/tracing purposes
+    @property(nonatomic, readonly)         long          id;
+    //! HTTP method (GET, POST, ...)
+    @property(nonatomic, readonly, strong) NSString*     method;
+    //! HTTP path, including listener's prefix and any provided query parameters
+    @property(nonatomic, readonly, strong) NSString*     path;
+    //! HTTP headers
+    @property(nonatomic, readonly, strong) NSDictionary* headers;
+    //! HTTP body/content
+    @property(nonatomic, readonly, strong) NSString*     body;
+@end
+
+/**
+ * Trouter HTTP-like response (app -> Trouter -> service)
+ *
+ * Represents one outgoing response to be sent by Trouter Client. Always set
+ * the status code, add any extra headers or body, then call `send()`.
+ */
+@protocol TrouterResponse <NSObject>
+    //! Request/response ID, useful for logging/debugging/tracing purposes
+    @property(nonatomic, readonly)         long          id;
+    //! HTTP status code (200, 404, ...), mandatory
+    @property(nonatomic, assign)           int           status;
+    //! HTTP headers, optional
+    @property(nonatomic, readonly, strong) NSDictionary* headers;
+    //! HTTP body/content, optional
+    @property(nonatomic, strong)           NSString*     body;
+
+    /**
+     * Send the response
+     *
+     * Trouter will add just a few of its own headers and otherwise forward the
+     * response to the originating service that had sent the request.
+     *
+     * A successful return value `OK` means only that the response message has
+     * been accepted and prepared for sending back. The actual transmission will
+     * happen asynchronously later and might still fail for various reasons.
+     *
+     * @return TrouterSendResponseResultOK if successful, other code if not
+     */
+    -(TrouterSendResponseResult)send;
+@end
+
+/**
+ * Information about the current Trouter connection
+ *
+ * Received in `Listener.onTrouterConnected()` every time the connection
+ * parameters change.
+ */
+@protocol TrouterConnectionInfo <NSObject>
+    //! Base URL used for routing messages from services to this client
+    //! instance, i.e. not specific to a particular listener
+    @property(nonatomic, readonly, strong) NSString* baseEndpointUrl;
+    //! Tells if this `baseEndpointUrl` is different from the previous one and
+    //! therefore if any dependent service registrations need to be updated to
+    //! know where to send data
+    @property(nonatomic, readonly)         BOOL      newEndpointUrl;
+    //! Base URL prefix used for routing messages from clients to this client -
+    //! replace the URL base (protocol + hostname) of `baseEndpointUrl` (or
+    //! another per-listener endpoint URL) with this value to obtain the full
+    //! client-to-client URL.
+    @property(nonatomic, readonly, strong) NSString* c2cUrlBase;
+    //! ID of this Trouter client, should stay the same between reconnects
+    @property(nonatomic, readonly, strong) NSString* clientId;
+    //! ID of the current Trouter connection, can change between reconnects
+    @property(nonatomic, readonly, strong) NSString* connectionId;
+    //! Expected lifetime of the current connection (ID) in seconds, as
+    //! determined by Trouter Service
+    @property(nonatomic, readonly)         int       connectionTtlSec;
+@end
+
+/**
+ * Trouter listener
+ *
+ * Interface implemented by application to receive Trouter callbacks
+ */
+@protocol TrouterListener <NSObject>
+    @required
+
+    /**
+     * Called when Trouter connection is (re-)established
+     *
+     * This is important mostly because of the `endpointUrl` as the URL where
+     * messages are sent to by the originating service(s). Only after receiving
+     * this callback and learning the Endpoint URL can the application register
+     * the established channel for receiving messages.
+     *
+     * The Endpoint URL is intended for service-to-service communication, only
+     * whitelisted authenticated services can access it and initiate Trouter
+     * requests. Use `c2cUrlBase` from `connectionInfo` to obtain a similar URL
+     * for client-to-client communication - see also `TrouterReplaceUrlBase()`.
+     *
+     * @note Called from an internal worker thread, listeners should offload any
+     *       longer processing asynchronously.
+     *
+     * @param endpointUrl    A URL used for routing messages from services to
+     *                       this listener
+     * @param connectionInfo Additional Trouter connection information
+     */
+    -(void)onTrouterConnected:(NSString*)endpointUrl :(id<TrouterConnectionInfo>)connectionInfo;
+
+    /**
+     * Called when Trouter receives a request intended for this listener
+     *
+     * Application can inspect the contents of the incoming message by looking
+     * at `request`, then fill in the outgoing `reponse` and send it back by
+     * invoking its method `send()`.
+     *
+     * This can be done both synchronously when this method is called, or at a
+     * later time asynchronously from any other context, if the application
+     * stores the `response` object aside.
+     *
+     * In any case, a response ought to be sent to every received request. If
+     * it is not, Trouter client will send a 504 (Timeout) message itself after
+     * a configured time, but that will needlessly show up as an error on the
+     * service side, even if you have processed the message successfully.
+     *
+     * For most simple applications, just sending a response with 200 (OK) right
+     * away should be good enough.
+     *
+     * @param request  Incoming request object (read-only)
+     * @param response Outgoing response object (to be filled in and sent)
+     */
+    -(void)onTrouterRequest:(id<TrouterRequest>)request :(id<TrouterResponse>)response;
+
+    @optional
+
+    /**
+     * Called when Trouter connection drops
+     *
+     * No incoming requests can be received for now, no outgoing responses can
+     * be sent either. Trouter client will reconnect as soon as possible.
+     *
+     * This state is most commonly caused by some temporary network issues
+     * (switching from Wi-Fi to a wired network, bad signal etc.) or things
+     * like a sleep/resume transition on the device.
+     *
+     * @note This method does not need to be implemented.
+     */
+    -(void)onTrouterDisconnected;
+@end
+
+/**
+ * Trouter client
+ *
+ * Use to register and unregister your listeners. Calls are forwarded to the
+ * underlying implementation, whatever that is on the current platform.
+ *
+ * The class does some wrapping inside and therefore unregisters all registered
+ * listeners upon its destruction. Keep it alive (referenced) as long as your
+ * listeners need to work (be notified).
+ */
+@protocol TrouterClient <NSObject>
+    /**
+     * Register a listener
+     *
+     * The specified listener will now be notified about any Trouter events. An
+     * initial `onTrouterConnected()` callback will be received automatically
+     * right away if Trouter is already connected, so that the listener can
+     * learn the Endpoint URL etc.
+     *
+     * There can be only one listener registered for each `path`, but the path
+     * can naturally comprise of multiple levels separated with a slash. The
+     * listener with the longest, most specific matching path prefix for an
+     * incoming message will be invoked to handle it.
+     *
+     * This method is very light-weight and can be called at any time.
+     *
+     * @param listener Listener object to register
+     * @param path     HTTP-like relative path to register (e.g. '/foo')
+     * @return `true` if successfully registered,
+     *         `false` if there already is a registered listener for this exact
+     *         path or if the given path is invalid
+     */
+    -(BOOL)registerListener:(id<TrouterListener>)listener forPath:(NSString*)path;
+
+    /**
+     * Unregister a listener
+     *
+     * The specified listener will not be notified about any Trouter events
+     * anymore. `onTrouterDisconnected()` will not be called automatically
+     * during unregistration.
+     *
+     * All registrations of this `Listener` object (i.e. possibly more than one,
+     * registered with different paths) will be unregistered.
+     *
+     * This method is very light-weight and can be called at any time.
+     *
+     * @param listener Listener object to unregister
+     * @return `true` if successfully unregistered,
+     *         `false` if not registered in the first place
+     */
+    -(BOOL)unregisterListener:(id<TrouterListener>)listener;
+
+    /**
+     * Sets the user activity state on this endpoint/device
+     *
+     * The activity state will be sent to the service if it is different
+     * from the previously sent state, upon reconnect, or under other
+     * circumstances fully in the discretion of the client.
+     */
+    -(void)setUserActivityState:(UserActivityState)state;
+@end
+
+/**
+ * Helper function to replace URL base (protocol + hostname)
+ *
+ * Useful when converting Trouter Endpoint URL to its client-to-client variant
+ * with `TrouterConnectionInfo.c2cUrlBase`.
+ */
+NSString* TrouterReplaceUrlBase(NSString* existingUrl, NSString* newBase);

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/TrouterSkypetokenProvider.h
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/TrouterSkypetokenProvider.h
@@ -1,0 +1,56 @@
+/**
+ * Represents a callback for trouter registrar client to acquire authentication token for its requests
+ */
+@protocol TrouterSkypetokenProvider <NSObject>
+/**
+ * Called back whenever Registrar client needs X-Skypetoken auth header value for its next request
+ * It is recommended that auth tokens are cached in the upper layer and returned immediately
+ *
+ * forceRefresh parameter is set to true when Registrar client hits 401 Unauthorized error
+ * which may indicate an expired or revoked token so the hint is to ask for new token
+ * to be issued instead of returning cached one
+ */
+-(NSString*)getSkypetoken:(BOOL)forceRefresh;
+@end
+
+/**
+ * Represents a setter of authentication headers for trouter client requests.
+ * Created for convenience of each call back to ITrouterAuthHeadersProvider
+ */
+@protocol TrouterAuthHeadersSetter <NSObject>
+/**
+* Sets the authentication headers for trouter client request
+* Can be safely called from within  ITrouterAuthHeadersProvider.getAuthHeaders()
+*
+* Example of the authHeaders value to set is:
+*   "X-Skypetoken: eyJhbGc..."
+*/
+-(void)set:(NSString*)authHeaders;
+@end
+
+/**
+ * Represents a callback for trouter client to acquire authentication headers for its requests
+ */
+@protocol TrouterAuthHeadersProvider <NSObject>
+/**
+ * Called back whenever Trouter client needs authentication headers for its next request
+ * It is recommended that auth tokens are cached in the upper layer and returned immediately
+ *
+ * @param forceRefresh the parameter is set to true when Trouter client hits 401 Unauthorized error
+ * which may indicate an expired or revoked token so the hint is to ask for new token
+ * to be issued instead of returning cached one
+ */
+-(void)getAuthHeaders:(BOOL)forceRefresh :(id<TrouterAuthHeadersSetter>)authHeaders;
+@end
+
+/**
+ * Adapter of TrouterSkypetokenProvider to TrouterAuthHeadersProvider
+ * For the convenience of using TrouterSkypetokenProvider for both Trouter client and Registration authentication
+ */
+@interface TrouterSkypetokenAuthHeaderProvider : NSObject<TrouterAuthHeadersProvider>
+{
+    id<TrouterSkypetokenProvider> skypetokenProvider;
+}
+-(id)initWithSkypetokenProvider:(id<TrouterSkypetokenProvider>)skypetokenProvider;
+-(void)getAuthHeaders:(BOOL)forceRefresh :(id<TrouterAuthHeadersSetter>)authHeaders;
+@end

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/TrouterUrlRegistrar.h
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterHeaderFiles/TrouterUrlRegistrar.h
@@ -1,0 +1,45 @@
+#import "Trouter.h"
+#import "TrouterSkypetokenProvider.h"
+
+
+@interface RegistrarResponse : NSObject
+@property(nonatomic, readonly, strong) NSString* message;
+@property(nonatomic, readonly) int code;
++ (id)createWithData:(NSData*)data
+            response:(NSURLResponse*)response;
+@end
+
+/*
+ * Holds parameters of client Registration record
+ * that can be POSTed automatically by Trouter client on behalf of the application
+ */
+@interface TrouterUrlRegistrationData : NSObject
+@property(nonatomic, readonly, strong) NSString* applicationId;     // mandatory, should match appIds value set in PNH templates
+@property(nonatomic, readonly, strong) NSString* registrationId;    // optional, GUID is generated if null or empty
+@property(nonatomic, readonly, strong) NSString* platform;          // optional
+@property(nonatomic, readonly, strong) NSString* platformUiVersion; // mandatory, take the value from "clientVersion" set to TrouterClientHost
+@property(nonatomic, readonly, strong) NSString* templateKey;       // mandatory, should match templateKeys value set in PNH templates
+@property(nonatomic, readonly, strong) NSString* productContext;    // optional, currently only used by TFL
+@property(nonatomic, readonly, strong) NSString* context;           // optional
+
++ (id)createWithApplicationId:(NSString*)applicationId
+               registrationId:(NSString*)registrationId
+                     platform:(NSString*)platform
+            platformUiVersion:(NSString*)platformUiVersion
+                  templateKey:(NSString*)templateKey
+               productContext:(NSString*)productContext
+                      context:(NSString*)context;
+@end
+
+
+/*
+ * Provides functionality of automatically tracking Trouter URL updates
+ * and registering them in EDF Registrar on behalf of the application
+ */
+@interface TrouterUrlRegistrar : NSObject
++ (id)createWithSkypetokenProvider:(id<TrouterSkypetokenProvider>)skypetokenProvider // mandatory, auth header provider
+                  registrationData:(TrouterUrlRegistrationData*)registrationData     // mandatory
+      registrarHostnameAndBasePath:(NSString*)registrarHostnameAndBasePath           // optional, defaults to edge.skype.com/registrar/prod
+               maxRegistrationTtlS:(int)maxRegistrationTtlS;                         // optional, in seconds, limits registration TTL, min value is 3600
+- (void)onTrouterConnected:(id<TrouterConnectionInfo>)connectionInfo;
+@end

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterModulesPrivate/module.modulemap
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterModulesPrivate/module.modulemap
@@ -1,0 +1,15 @@
+//
+//  module.modulemap
+//  AzureCommunicationSignaling
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+module TrouterModulePrivate {
+    header "../TrouterHeaderFiles/SelfHostedTrouterClient.h"
+    header "../TrouterHeaderFiles/Trouter.h"
+    header "../TrouterHeaderFiles/TrouterSkypetokenProvider.h"
+    header "../TrouterHeaderFiles/TrouterUrlRegistrar.h"
+    export *
+}

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterNotificationPayload.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterNotificationPayload.swift
@@ -1,0 +1,184 @@
+//
+//  TrouterNotificationPayload.swift
+//  AzureCommunicationSignaling
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+class BasePayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var senderId: String
+    var recipientId: String
+    var groupId: String
+}
+
+class MessageReceivedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var senderId: String
+    var recipientId: String
+    var transactionId: String
+    var groupId: String
+    var messageId: String
+    var messageType: String
+    var messageBody: String
+    var senderDisplayName: String
+    var clientMessageId: String
+    var originalArrivalTime: String
+    var priority: String
+    var version: String
+}
+
+class TypingIndicatorReceivedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var senderId: String
+    var recipientId: String
+    var groupId: String
+    var version: String
+    var originalArrivalTime: String
+}
+
+class ReadReceiptMessageBody: Decodable {
+    var user: String
+    var consumptionhorizon: String
+    var messageVisibilityTime: Int
+    var version: String
+}
+
+class ReadReceiptReceivedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var senderId: String
+    var recipientId: String
+    var groupId: String
+    var messageId: String
+    var clientMessageId: String
+    var messageBody: String
+}
+
+class MessageEditedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var senderId: String
+    var recipientId: String
+    var groupId: String
+    var messageId: String
+    var clientMessageId: String
+    var senderDisplayName: String
+    var messageBody: String
+    var version: String
+    var edittime: String
+    var originalArrivalTime: String
+}
+
+class MessageDeletedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var senderId: String
+    var recipientId: String
+    var groupId: String
+    var messageId: String
+    var clientMessageId: String
+    var senderDisplayName: String
+    var version: String
+    var deletetime: String
+    var originalArrivalTime: String
+}
+
+class ChatThreadPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var threadId: String
+    var version: String
+}
+
+class ChatParticipantPayload: Decodable {
+    var participantId: String
+    var displayName: String
+    var shareHistoryTime: Int?
+}
+
+class ChatThreadCreatedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var threadId: String
+    var version: String
+    var createTime: String
+    var createdBy: String
+    var members: String
+    var properties: String
+}
+
+class ChatThreadPropertiesPayload: Decodable {
+    var topic: String
+}
+
+class ChatThreadPropertiesUpdatedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var threadId: String
+    var version: String
+    var editTime: String
+    var editedBy: String
+    var properties: String
+}
+
+class ChatThreadDeletedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var threadId: String
+    var version: String
+    var deleteTime: String
+    var deletedBy: String
+}
+
+class ParticipantsAddedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var threadId: String
+    var version: String
+    var time: String
+    var addedBy: String
+    var participantsAdded: String
+}
+
+class ParticipantsRemovedPayload: Decodable {
+    // swiftlint:disable identifier_name
+    var _eventId: Int
+    // swiftlint:enable identifier_name
+    var threadId: String
+    var version: String
+    var time: String
+    var removedBy: String
+    var participantsRemoved: String
+}
+
+var eventIds: [Int: ChatEventId] =
+    [
+        200: ChatEventId.chatMessageReceived,
+        245: ChatEventId.typingIndicatorReceived,
+        246: ChatEventId.readReceiptReceived,
+        247: ChatEventId.chatMessageEdited,
+        248: ChatEventId.chatMessageDeleted,
+        257: ChatEventId.chatThreadCreated,
+        258: ChatEventId.chatThreadPropertiesUpdated,
+        259: ChatEventId.chatThreadDeleted,
+        260: ChatEventId.participantsAdded,
+        261: ChatEventId.participantsRemoved
+    ]

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterSettings.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterSettings.swift
@@ -1,0 +1,42 @@
+//
+//  TrouterSettings.swift
+//  AzureCommunicationSignaling
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import TrouterModulePrivate
+
+// swiftlint:disable force_cast
+var defaultRegistrationData = TrouterUrlRegistrationData.create(
+    withApplicationId: "AcsiOS_test",
+    registrationId: nil,
+    platform: "SPOOL",
+    platformUiVersion: "0.0.0",
+    templateKey: "AcsiOS_Chat_test_1.1",
+    productContext: nil,
+    context: ""
+) as! TrouterUrlRegistrationData
+// swiftlint:enable force_cast
+
+var defaultClientVersion = "1.0.0"
+var defaultTrouterHostname = "go.trouter-int.skype.net/v4/a"
+var defaultRegistrarHostnameAndBasePath = "edge.skype.net/registrar/testenv"
+
+func createRegistrationData() -> TrouterUrlRegistrationData {
+    return defaultRegistrationData
+}
+
+func getClientVersion() -> String {
+    return defaultClientVersion
+}
+
+func getTrouterHostname() -> String {
+    return defaultTrouterHostname
+}
+
+func getRegistrarHostnameAndBasePath() -> String {
+    return defaultRegistrarHostnameAndBasePath
+}

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterUtils.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/TrouterUtils.swift
@@ -1,0 +1,391 @@
+//
+//  TrouterUtils.swift
+//  AzureCommunicationSignaling
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AzureCore
+import Foundation
+import TrouterModulePrivate
+
+func toEventPayload(request: TrouterRequest, chatEventId: ChatEventId) -> Any? {
+    do {
+        switch chatEventId {
+        case ChatEventId.chatMessageReceived:
+            return try toChatMessageReceivedEvent(request: request)
+        case ChatEventId.typingIndicatorReceived:
+            return try toTypingIndicatorReceivedEvent(request: request)
+        case ChatEventId.readReceiptReceived:
+            return try toReadReceiptReceivedEvent(request: request)
+        case ChatEventId.chatMessageEdited:
+            return try toChatMessageEditedEvent(request: request)
+        case ChatEventId.chatMessageDeleted:
+            return try toChatMessageDeletedEvent(request: request)
+        case ChatEventId.chatThreadCreated:
+            return try toChatThreadCreatedEvent(request: request)
+        case ChatEventId.chatThreadPropertiesUpdated:
+            return try toChatThreadPropertiesUpdatedEvent(request: request)
+        case ChatEventId.chatThreadDeleted:
+            return try toChatThreadDeletedEvent(request: request)
+        case ChatEventId.participantsAdded:
+            return try toParticipantsAddedEvent(request: request)
+        case ChatEventId.participantsRemoved:
+            return try toParticipantsRemovedEvent(request: request)
+        }
+    } catch {
+        return nil
+    }
+}
+
+func toChatMessageReceivedEvent(request: TrouterRequest) throws -> ChatMessageReceivedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let messageReceivedPayload: MessageReceivedPayload = try JSONDecoder()
+            .decode(MessageReceivedPayload.self, from: requestJsonData)
+
+        let chatMessageReceivedEvent =
+            ChatMessageReceivedEvent(
+                threadId: messageReceivedPayload.groupId,
+                sender: CommunicationUser(communicationUserId: messageReceivedPayload.senderId),
+                recipient: CommunicationUser(
+                    communicationUserId: messageReceivedPayload
+                        .recipientId
+                ),
+                id: messageReceivedPayload.messageId,
+                senderDisplayName: messageReceivedPayload.senderDisplayName,
+                createdOn: messageReceivedPayload.originalArrivalTime,
+                version: messageReceivedPayload.version,
+                type: messageReceivedPayload.messageType,
+                content: messageReceivedPayload.messageBody,
+                priority: messageReceivedPayload.priority
+            )
+
+        return chatMessageReceivedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toTypingIndicatorReceivedEvent(request: TrouterRequest) throws -> TypingIndicatorReceivedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let typingIndicatorReceivedPayload: TypingIndicatorReceivedPayload = try JSONDecoder()
+            .decode(TypingIndicatorReceivedPayload.self, from: requestJsonData)
+
+        let typingIndicatorReceivedEvent =
+            TypingIndicatorReceivedEvent(
+                threadId: typingIndicatorReceivedPayload.groupId,
+                sender: CommunicationUser(
+                    communicationUserId: typingIndicatorReceivedPayload
+                        .senderId
+                ),
+                recipient: CommunicationUser(
+                    communicationUserId: typingIndicatorReceivedPayload
+                        .recipientId
+                ),
+                version: typingIndicatorReceivedPayload.version,
+                receivedOn: typingIndicatorReceivedPayload.originalArrivalTime
+            )
+
+        return typingIndicatorReceivedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toReadReceiptReceivedEvent(request: TrouterRequest) throws -> ReadReceiptReceivedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let readReceiptReceivedPayload: ReadReceiptReceivedPayload = try JSONDecoder()
+            .decode(ReadReceiptReceivedPayload.self, from: requestJsonData)
+
+        let readReceiptMessageBodyJsonData = (readReceiptReceivedPayload.messageBody.data(using: .utf8))!
+
+        let readReceiptMessageBody: ReadReceiptMessageBody = try JSONDecoder()
+            .decode(ReadReceiptMessageBody.self, from: readReceiptMessageBodyJsonData)
+
+        let consumptionHorizon = readReceiptMessageBody.consumptionhorizon.split(separator: ";")
+
+        let readOn = String(consumptionHorizon[1])
+
+        let readReceiptEvent =
+            ReadReceiptReceivedEvent(
+                threadId: readReceiptReceivedPayload.groupId,
+                sender: CommunicationUser(
+                    communicationUserId: readReceiptReceivedPayload
+                        .senderId
+                ),
+                recipient: CommunicationUser(
+                    communicationUserId: readReceiptReceivedPayload
+                        .recipientId
+                ),
+                chatMessageId: readReceiptReceivedPayload.messageId,
+                readOn: readOn
+            )
+
+        return readReceiptEvent
+
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toChatMessageEditedEvent(request: TrouterRequest) throws -> ChatMessageEditedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let chatMessageEditedPayload: MessageEditedPayload = try JSONDecoder()
+            .decode(MessageEditedPayload.self, from: requestJsonData)
+
+        let chatMessageEditedEvent =
+            ChatMessageEditedEvent(
+                threadId: chatMessageEditedPayload.groupId,
+                sender: CommunicationUser(communicationUserId: chatMessageEditedPayload.senderId),
+                recipient: CommunicationUser(
+                    communicationUserId: chatMessageEditedPayload
+                        .recipientId
+                ),
+                id: chatMessageEditedPayload.messageId,
+                senderDisplayName: chatMessageEditedPayload.senderDisplayName,
+                createdOn: chatMessageEditedPayload.originalArrivalTime,
+                version: chatMessageEditedPayload.version,
+                content: chatMessageEditedPayload.messageBody,
+                editedOn: chatMessageEditedPayload.edittime
+            )
+
+        return chatMessageEditedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toChatMessageDeletedEvent(request: TrouterRequest) throws -> ChatMessageDeletedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let chatMessageDeletedPayload: MessageDeletedPayload = try JSONDecoder()
+            .decode(MessageDeletedPayload.self, from: requestJsonData)
+
+        let chatMessageDeletedEvent =
+            ChatMessageDeletedEvent(
+                threadId: chatMessageDeletedPayload.groupId,
+                sender: CommunicationUser(communicationUserId: chatMessageDeletedPayload.senderId),
+                recipient: CommunicationUser(
+                    communicationUserId: chatMessageDeletedPayload
+                        .recipientId
+                ),
+                id: chatMessageDeletedPayload.messageId,
+                senderDisplayName: chatMessageDeletedPayload.senderDisplayName,
+                createdOn: chatMessageDeletedPayload.originalArrivalTime,
+                version: chatMessageDeletedPayload.version,
+                deletedOn: chatMessageDeletedPayload.deletetime
+            )
+
+        return chatMessageDeletedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toChatThreadCreatedEvent(request: TrouterRequest) throws -> ChatThreadCreatedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let chatThreadCreatedPayload: ChatThreadCreatedPayload = try JSONDecoder()
+            .decode(ChatThreadCreatedPayload.self, from: requestJsonData)
+
+        let createdByJsonData = (chatThreadCreatedPayload.createdBy.data(using: .utf8))!
+        let createdByPayload: ChatParticipantPayload = try JSONDecoder()
+            .decode(ChatParticipantPayload.self, from: createdByJsonData)
+        let createdBy =
+            SignalingChatParticipant(
+                user: CommunicationUser(communicationUserId: createdByPayload.participantId),
+                displayName: createdByPayload.displayName
+            )
+
+        let membersJsonData = (chatThreadCreatedPayload.members.data(using: .utf8))!
+        let membersPayload: [ChatParticipantPayload] = try JSONDecoder()
+            .decode([ChatParticipantPayload].self, from: membersJsonData)
+        let participants: [SignalingChatParticipant] = membersPayload
+            .map { (memberPayload: ChatParticipantPayload) -> SignalingChatParticipant in
+                SignalingChatParticipant(
+                    user: CommunicationUser(communicationUserId: memberPayload.participantId),
+                    displayName: memberPayload.displayName
+                )
+            }
+
+        let propertiesJsonData = (chatThreadCreatedPayload.properties.data(using: .utf8))!
+        let propertiesPayload: ChatThreadPropertiesPayload = try JSONDecoder()
+            .decode(ChatThreadPropertiesPayload.self, from: propertiesJsonData)
+        let properties = ChatThreadProperties(topic: propertiesPayload.topic)
+
+        let chatThreadCreatedEvent =
+            ChatThreadCreatedEvent(
+                threadId: chatThreadCreatedPayload.threadId,
+                version: chatThreadCreatedPayload.version,
+                createdOn: chatThreadCreatedPayload.createTime,
+                properties: properties,
+                participants: participants,
+                createdBy: createdBy
+            )
+
+        return chatThreadCreatedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toChatThreadPropertiesUpdatedEvent(request: TrouterRequest) throws -> ChatThreadPropertiesUpdatedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let chatThreadPropertiesUpdatedPayload: ChatThreadPropertiesUpdatedPayload = try JSONDecoder()
+            .decode(ChatThreadPropertiesUpdatedPayload.self, from: requestJsonData)
+
+        let updatedByJsonData = (chatThreadPropertiesUpdatedPayload.editedBy.data(using: .utf8))!
+        let updatedByPayload: ChatParticipantPayload = try JSONDecoder()
+            .decode(ChatParticipantPayload.self, from: updatedByJsonData)
+        let updatedBy =
+            SignalingChatParticipant(
+                user: CommunicationUser(communicationUserId: updatedByPayload.participantId),
+                displayName: updatedByPayload.displayName
+            )
+
+        let propertiesJsonData = (chatThreadPropertiesUpdatedPayload.properties.data(using: .utf8))!
+        let propertiesPayload: ChatThreadPropertiesPayload = try JSONDecoder()
+            .decode(ChatThreadPropertiesPayload.self, from: propertiesJsonData)
+        let properties = ChatThreadProperties(topic: propertiesPayload.topic)
+
+        let chatThreadPropertiesUpdatedEvent =
+            ChatThreadPropertiesUpdatedEvent(
+                threadId: chatThreadPropertiesUpdatedPayload.threadId,
+                version: chatThreadPropertiesUpdatedPayload.version,
+                properties: properties,
+                updatedOn: chatThreadPropertiesUpdatedPayload.editTime,
+                updatedBy: updatedBy
+            )
+
+        return chatThreadPropertiesUpdatedEvent
+
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toChatThreadDeletedEvent(request: TrouterRequest) throws -> ChatThreadDeletedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let chatThreadDeletedPayload: ChatThreadDeletedPayload = try JSONDecoder()
+            .decode(ChatThreadDeletedPayload.self, from: requestJsonData)
+
+        let deletedByJsonData = (chatThreadDeletedPayload.deletedBy.data(using: .utf8))!
+        let deletedByPayload: ChatParticipantPayload = try JSONDecoder()
+            .decode(ChatParticipantPayload.self, from: deletedByJsonData)
+        let deletedBy = SignalingChatParticipant(
+            user: CommunicationUser(communicationUserId: deletedByPayload.participantId),
+            displayName: deletedByPayload.displayName
+        )
+
+        let chatThreadDeletedEvent =
+            ChatThreadDeletedEvent(
+                threadId: chatThreadDeletedPayload.threadId,
+                version: chatThreadDeletedPayload.version,
+                deletedOn: chatThreadDeletedPayload.deleteTime,
+                deletedBy: deletedBy
+            )
+
+        return chatThreadDeletedEvent
+
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toParticipantsAddedEvent(request: TrouterRequest) throws -> ParticipantsAddedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let participantsAddedPayload: ParticipantsAddedPayload = try JSONDecoder()
+            .decode(ParticipantsAddedPayload.self, from: requestJsonData)
+
+        let addeddByJsonData = (participantsAddedPayload.addedBy.data(using: .utf8))!
+        let addedByPayload: ChatParticipantPayload = try JSONDecoder()
+            .decode(ChatParticipantPayload.self, from: addeddByJsonData)
+        let addedBy = SignalingChatParticipant(
+            user: CommunicationUser(communicationUserId: addedByPayload.participantId),
+            displayName: addedByPayload.displayName
+        )
+
+        let participantsJsonData = (participantsAddedPayload.participantsAdded.data(using: .utf8))!
+        let participantsPayload: [ChatParticipantPayload] = try JSONDecoder()
+            .decode([ChatParticipantPayload].self, from: participantsJsonData)
+
+        let participants: [SignalingChatParticipant] = participantsPayload
+            .map { (memberPayload: ChatParticipantPayload) -> SignalingChatParticipant in
+                SignalingChatParticipant(
+                    user: CommunicationUser(communicationUserId: memberPayload.participantId),
+                    displayName: memberPayload.displayName,
+                    shareHistoryTime: toISO8601Date(unixTime: memberPayload.shareHistoryTime)
+                )
+            }
+
+        let participantsAddedEvent =
+            ParticipantsAddedEvent(
+                threadId: participantsAddedPayload.threadId,
+                version: participantsAddedPayload.version,
+                addedOn: participantsAddedPayload.time,
+                participantsAdded: participants,
+                addedBy: addedBy
+            )
+
+        return participantsAddedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toParticipantsRemovedEvent(request: TrouterRequest) throws -> ParticipantsRemovedEvent {
+    do {
+        let requestJsonData = request.body.data(using: .utf8)!
+        let participantsRemovedPayload: ParticipantsRemovedPayload = try JSONDecoder()
+            .decode(ParticipantsRemovedPayload.self, from: requestJsonData)
+
+        let removedByJsonData = (participantsRemovedPayload.removedBy.data(using: .utf8))!
+        let removedByPayload: ChatParticipantPayload = try JSONDecoder()
+            .decode(ChatParticipantPayload.self, from: removedByJsonData)
+        let removedBy = SignalingChatParticipant(
+            user: CommunicationUser(communicationUserId: removedByPayload.participantId),
+            displayName: removedByPayload.displayName
+        )
+
+        let participantsJsonData = (participantsRemovedPayload.participantsRemoved.data(using: .utf8))!
+        let participantsPayload: [ChatParticipantPayload] = try JSONDecoder()
+            .decode([ChatParticipantPayload].self, from: participantsJsonData)
+        let participants: [SignalingChatParticipant] = participantsPayload
+            .map { (memberPayload: ChatParticipantPayload) -> SignalingChatParticipant in
+                SignalingChatParticipant(
+                    user: CommunicationUser(communicationUserId: memberPayload.participantId),
+                    displayName: memberPayload.displayName,
+                    shareHistoryTime: toISO8601Date(unixTime: memberPayload.shareHistoryTime)
+                )
+            }
+
+        let participantsRemovedEvent =
+            ParticipantsRemovedEvent(
+                threadId: participantsRemovedPayload.threadId,
+                version: participantsRemovedPayload.version,
+                removedOn: participantsRemovedPayload.time,
+                participantsRemoved: participants,
+                removedBy: removedBy
+            )
+
+        return participantsRemovedEvent
+    } catch {
+        throw AzureError.client("Unable to decode with error: \(error)")
+    }
+}
+
+func toISO8601Date(unixTime: Int? = 0) -> String {
+    let unixTimeInMilliSeconds = Double(unixTime ?? 0) / 1000
+    let date = Date(timeIntervalSince1970: TimeInterval(unixTimeInMilliSeconds))
+    let iso8601DateFormatter = ISO8601DateFormatter()
+    iso8601DateFormatter.formatOptions = [.withInternetDateTime]
+    return iso8601DateFormatter.string(from: date)
+}

--- a/sdk/communication/AzureCommunicationChat/Source/Signalling/events/chat.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signalling/events/chat.swift
@@ -1,0 +1,311 @@
+//
+//  chat.swift
+//  AzureCommunicationSignaling
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+public class CommunicationUser {
+    public var communicationUserId: String
+
+    init(communicationUserId: String) {
+        self.communicationUserId = communicationUserId
+    }
+}
+
+public class SignalingChatParticipant {
+    public var user: CommunicationUser?
+    public var displayName: String?
+    public var shareHistoryTime: String?
+
+    init(user: CommunicationUser?, displayName: String? = nil, shareHistoryTime: String? = nil) {
+        self.user = user
+        self.displayName = displayName
+        self.shareHistoryTime = shareHistoryTime
+    }
+}
+
+public class ChatThreadProperties {
+    public var topic: String
+
+    init(topic: String) {
+        self.topic = topic
+    }
+}
+
+public class BaseEvent {
+    public var threadId: String
+    public var sender: CommunicationUser?
+    public var recipient: CommunicationUser?
+
+    init(threadId: String, sender: CommunicationUser?, recipient: CommunicationUser?) {
+        self.threadId = threadId
+        self.sender = sender
+        self.recipient = recipient
+    }
+}
+
+public class ChatThreadEvent {
+    public var threadId: String
+    public var version: String
+
+    init(threadId: String, version: String) {
+        self.threadId = threadId
+        self.version = version
+    }
+}
+
+public class ChatMessageEvent: BaseEvent {
+    public var id: String
+    public var senderDisplayName: String?
+    public var createdOn: String
+    public var version: String
+
+    init(
+        threadId: String,
+        sender: CommunicationUser?,
+        recipient: CommunicationUser?,
+        id: String,
+        senderDisplayName: String? = nil,
+        createdOn: String,
+        version: String
+    ) {
+        self.id = id
+        self.senderDisplayName = senderDisplayName
+        self.createdOn = createdOn
+        self.version = version
+        super.init(threadId: threadId, sender: sender, recipient: recipient)
+    }
+}
+
+public class ChatMessageReceivedEvent: ChatMessageEvent {
+    public var type: String
+    public var content: String
+    public var priority: String
+
+    init(
+        threadId: String,
+        sender: CommunicationUser?,
+        recipient: CommunicationUser?,
+        id: String,
+        senderDisplayName: String? = nil,
+        createdOn: String,
+        version: String,
+        type: String,
+        content: String,
+        priority: String
+    ) {
+        self.type = type
+        self.content = content
+        self.priority = priority
+        super.init(
+            threadId: threadId,
+            sender: sender,
+            recipient: recipient,
+            id: id,
+            senderDisplayName: senderDisplayName,
+            createdOn: createdOn,
+            version: version
+        )
+    }
+}
+
+public class ChatMessageEditedEvent: ChatMessageEvent {
+    public var content: String
+    public var editedOn: String
+
+    init(
+        threadId: String,
+        sender: CommunicationUser?,
+        recipient: CommunicationUser?,
+        id: String,
+        senderDisplayName: String? = nil,
+        createdOn: String,
+        version: String,
+        content: String,
+        editedOn: String
+    ) {
+        self.content = content
+        self.editedOn = editedOn
+        super.init(
+            threadId: threadId,
+            sender: sender,
+            recipient: recipient,
+            id: id,
+            senderDisplayName: senderDisplayName,
+            createdOn: createdOn,
+            version: version
+        )
+    }
+}
+
+public class ChatMessageDeletedEvent: ChatMessageEvent {
+    public var deletedOn: String
+
+    init(
+        threadId: String,
+        sender: CommunicationUser?,
+        recipient: CommunicationUser?,
+        id: String,
+        senderDisplayName: String? = nil,
+        createdOn: String,
+        version: String,
+        deletedOn: String
+    ) {
+        self.deletedOn = deletedOn
+        super.init(
+            threadId: threadId,
+            sender: sender,
+            recipient: recipient,
+            id: id,
+            senderDisplayName: senderDisplayName,
+            createdOn: createdOn,
+            version: version
+        )
+    }
+}
+
+public class TypingIndicatorReceivedEvent: BaseEvent {
+    public var version: String
+    public var receivedOn: String
+
+    init(
+        threadId: String,
+        sender: CommunicationUser?,
+        recipient: CommunicationUser?,
+        version: String,
+        receivedOn: String
+    ) {
+        self.version = version
+        self.receivedOn = receivedOn
+        super.init(threadId: threadId, sender: sender, recipient: recipient)
+    }
+}
+
+public class ReadReceiptReceivedEvent: BaseEvent {
+    public var chatMessageId: String
+    public var readOn: String
+
+    init(
+        threadId: String,
+        sender: CommunicationUser?,
+        recipient: CommunicationUser?,
+        chatMessageId: String,
+        readOn: String
+    ) {
+        self.chatMessageId = chatMessageId
+        self.readOn = readOn
+        super.init(threadId: threadId, sender: sender, recipient: recipient)
+    }
+}
+
+public class ChatThreadCreatedEvent: ChatThreadEvent {
+    public var createdOn: String
+    public var properties: ChatThreadProperties?
+    public var participants: [SignalingChatParticipant]?
+    public var createdBy: SignalingChatParticipant?
+
+    init(
+        threadId: String,
+        version: String,
+        createdOn: String,
+        properties: ChatThreadProperties?,
+        participants: [SignalingChatParticipant]?,
+        createdBy: SignalingChatParticipant?
+    ) {
+        self.createdOn = createdOn
+        self.properties = properties
+        self.participants = participants
+        self.createdBy = createdBy
+        super.init(threadId: threadId, version: version)
+    }
+}
+
+public class ChatThreadPropertiesUpdatedEvent: ChatThreadEvent {
+    public var properties: ChatThreadProperties?
+    public var updatedOn: String
+    public var updatedBy: SignalingChatParticipant?
+
+    init(
+        threadId: String,
+        version: String,
+        properties: ChatThreadProperties?,
+        updatedOn: String,
+        updatedBy: SignalingChatParticipant?
+    ) {
+        self.properties = properties
+        self.updatedOn = updatedOn
+        self.updatedBy = updatedBy
+        super.init(threadId: threadId, version: version)
+    }
+}
+
+public class ChatThreadDeletedEvent: ChatThreadEvent {
+    public var deletedOn: String
+    public var deletedBy: SignalingChatParticipant?
+
+    init(
+        threadId: String,
+        version: String,
+        deletedOn: String,
+        deletedBy: SignalingChatParticipant?
+    ) {
+        self.deletedOn = deletedOn
+        self.deletedBy = deletedBy
+        super.init(threadId: threadId, version: version)
+    }
+}
+
+public class ParticipantsAddedEvent: ChatThreadEvent {
+    public var addedOn: String
+    public var participantsAdded: [SignalingChatParticipant]?
+    public var addedBy: SignalingChatParticipant?
+
+    init(
+        threadId: String,
+        version: String,
+        addedOn: String,
+        participantsAdded: [SignalingChatParticipant]?,
+        addedBy: SignalingChatParticipant?
+    ) {
+        self.addedOn = addedOn
+        self.participantsAdded = participantsAdded
+        self.addedBy = addedBy
+        super.init(threadId: threadId, version: version)
+    }
+}
+
+public class ParticipantsRemovedEvent: ChatThreadEvent {
+    public var removedOn: String
+    public var participantsRemoved: [SignalingChatParticipant]?
+    public var removedBy: SignalingChatParticipant?
+
+    init(
+        threadId: String,
+        version: String,
+        removedOn: String,
+        participantsRemoved: [SignalingChatParticipant]?,
+        removedBy: SignalingChatParticipant?
+    ) {
+        self.removedOn = removedOn
+        self.participantsRemoved = participantsRemoved
+        self.removedBy = removedBy
+        super.init(threadId: threadId, version: version)
+    }
+}
+
+public enum ChatEventId: String {
+    case chatMessageReceived = "chatMessageReceived"
+    case typingIndicatorReceived = "typingIndicatorReceived"
+    case readReceiptReceived = "readReceiptReceived"
+    case chatMessageEdited = "chatMessageEdited"
+    case chatMessageDeleted = "chatMessageDeleted"
+    case chatThreadCreated = "chatThreadCreated"
+    case chatThreadPropertiesUpdated = "chatThreadPropertiesUpdated"
+    case chatThreadDeleted = "chatThreadDeleted"
+    case participantsAdded = "participantsAdded"
+    case participantsRemoved = "participantsRemoved"
+}


### PR DESCRIPTION
Created fresh branch because too many rebase conflicts
- Added convenience initializer to replace getSignallingClient() method
- In listeners use ChatEventId as parameter instead of string
- Remove fatalError in CommunicationSignallingClient
- Throw exception in start/stop if signalling client doesn't exist, so user knows notifications are not working

After preview4 PR goes in I will rebase this branch again so we are up to date with master. Next I will update the signalling schema