### PR TITLE
Pin MSAL version to avoid broken release of MSAL 1.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@
   libraries.
 
 ### Breaking Changes
+
 **Azure Communication Chat Service**
   - The `baseUrl` parameter has been renamed to `endpoint` in the `AzureCommunicationChatClient` initializers.
 

--- a/Podfile
+++ b/Podfile
@@ -60,35 +60,35 @@ end
 
 target 'AzureIdentity' do
   project 'sdk/identity/AzureIdentity/AzureIdentity'
-  pod 'MSAL', '1.1.2'
+  pod 'MSAL', '1.1.15'
 
   target 'AzureIdentityTests' do
     inherit! :search_paths
-    pod 'MSAL', '1.1.2'
+    pod 'MSAL', '1.1.15'
   end
 end
 
 target 'AzureStorageBlob' do
   project 'sdk/storage/AzureStorageBlob/AzureStorageBlob'
-  pod 'MSAL', '1.1.2'
+  pod 'MSAL', '1.1.15'
 
   target 'AzureStorageBlobTests' do
     inherit! :search_paths
-    pod 'MSAL', '1.1.2'
+    pod 'MSAL', '1.1.15'
   end
 end
 
 target 'AzureSDKDemoSwift' do
   project 'examples/AzureSDKDemoSwift/AzureSDKDemoSwift'
-  pod 'MSAL', '1.1.2'
+  pod 'MSAL', '1.1.15'
 end
 
 target 'AzureStorageBlobDemo' do
   project 'examples/AzureStorageBlobDemo/AzureStorageBlobDemo'
-  pod 'MSAL', '1.1.2'
+  pod 'MSAL', '1.1.15'
 end
 
 target 'AzureSDKDemoSwiftUI' do
   project 'examples/AzureSDKDemoSwiftUI/AzureSDKDemoSwiftUI'
-  pod 'MSAL', '1.1.2'
+  pod 'MSAL', '1.1.15'
 end

--- a/Podfile
+++ b/Podfile
@@ -60,35 +60,35 @@ end
 
 target 'AzureIdentity' do
   project 'sdk/identity/AzureIdentity/AzureIdentity'
-  pod 'MSAL', '~> 1.1.2'
+  pod 'MSAL', '1.1.2'
 
   target 'AzureIdentityTests' do
     inherit! :search_paths
-    pod 'MSAL', '~> 1.1.2'
+    pod 'MSAL', '1.1.2'
   end
 end
 
 target 'AzureStorageBlob' do
   project 'sdk/storage/AzureStorageBlob/AzureStorageBlob'
-  pod 'MSAL', '~> 1.1.2'
+  pod 'MSAL', '1.1.2'
 
   target 'AzureStorageBlobTests' do
     inherit! :search_paths
-    pod 'MSAL', '~> 1.1.2'
+    pod 'MSAL', '1.1.2'
   end
 end
 
 target 'AzureSDKDemoSwift' do
   project 'examples/AzureSDKDemoSwift/AzureSDKDemoSwift'
-  pod 'MSAL', '~> 1.1.2'
+  pod 'MSAL', '1.1.2'
 end
 
 target 'AzureStorageBlobDemo' do
   project 'examples/AzureStorageBlobDemo/AzureStorageBlobDemo'
-  pod 'MSAL', '~> 1.1.2'
+  pod 'MSAL', '1.1.2'
 end
 
 target 'AzureSDKDemoSwiftUI' do
   project 'examples/AzureSDKDemoSwiftUI/AzureSDKDemoSwiftUI'
-  pod 'MSAL', '~> 1.1.2'
+  pod 'MSAL', '1.1.2'
 end


### PR DESCRIPTION
Workaround for:
https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1280