### PR TITLE
Exclude Chat's swagger config file in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,8 @@ let package = Package(
             exclude: [
                 "README.md",
                 "Tests",
-                "Source/Supporting Files"
+                "Source/Supporting Files",
+                "Swagger/CONFIG.md"
             ],
             sources: ["Source"]
         ),


### PR DESCRIPTION
Prevent the warnings