### PR TITLE
Add tagging on release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -38,7 +38,7 @@ stages:
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:
-                        ArtifactLocation: $(Pipeline.Workspace)/sdk/${{}}/${{parameters.ArtifactName}}
+                        ArtifactLocation: $(Pipeline.Workspace)/sdk/${{parameters.ServiceDirectory}}/${{parameters.ArtifactName}}
                         PackageRepository: CocoaPods
                         ReleaseSha: $(Build.SourceVersion)
 

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -38,7 +38,7 @@ stages:
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:
-                        ArtifactLocation: $(Pipeline.Workspace)/sdk/${{parameters.ServiceDirectory}}/${{parameters.ArtifactName}}
+                        ArtifactLocation: $(Pipeline.Workspace)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
                         PackageRepository: CocoaPods
                         ReleaseSha: $(Build.SourceVersion)
 

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -38,7 +38,7 @@ stages:
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:
-                        ArtifactLocation: $(Pipeline.Workspace)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+                        ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
                         PackageRepository: CocoaPods
                         ReleaseSha: $(Build.SourceVersion)
 

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -60,7 +60,7 @@ stages:
                         echo "Pretend we are publishing to CocoaPods trunk.""
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
-            displayName: "Publish to CocoaPods Trunk"
+            displayName: "Publish to SPM Mirrors"
             condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
             environment: cocoapodstrunk
             dependsOn: TagRepository

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -36,12 +36,11 @@ stages:
                   steps:
                     - checkout: self
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                    # TODO: Will need to be adapted to work for Cocoapods (we'll read versions from the Cocoapod version specs)
-                    # - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                    #   parameters:
-                    #     ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.groupId}}/${{artifact.name}}
-                    #     PackageRepository: Maven
-                    #     ReleaseSha: $(Build.SourceVersion)
+                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                      parameters:
+                        ArtifactLocation: $(Pipeline.Workspace)/sdk/${{}}/${{parameters.ArtifactName}}
+                        PackageRepository: CocoaPods
+                        ReleaseSha: $(Build.SourceVersion)
 
           - deployment: PublishPackageToCocoaPodsTrunk
             displayName: "Publish to CocoaPods Trunk"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -21,7 +21,7 @@ function ComputeCocoaPodsSpecUrl($PackageId, $PackageVersion)
     return $url
 }
 
-# Returns the maven (really sonatype) publish status of a package id and version.
+# Returns the CocoaPods trunk publish status of a package id and version.
 function IsCocoaPodsPackageVersionPublished($PackageId, $PackageVersion)
 {
     $url = ComputeCocoaPodsSpecUrl -PackageId $PackageId -PackageVersion $PackageVersion
@@ -30,8 +30,7 @@ function IsCocoaPodsPackageVersionPublished($PackageId, $PackageVersion)
 
     try
     {
-        $uri = "https://oss.sonatype.org/content/repositories/releases/$groupId/$pkgId/$pkgVersion/$pkgId-$pkgVersion.pom"
-        $podspecContent = Invoke-RestMethod -MaximumRetryCount 3 -RetryIntervalSec 10 -Method "GET" -uri $uri
+        $podspecContent = Invoke-RestMethod -MaximumRetryCount 3 -RetryIntervalSec 10 -Method "GET" -Uri $url
 
         if ($podspecContent -ne $null -or $podspecContent.Length -eq 0)
         {
@@ -59,7 +58,7 @@ function IsCocoaPodsPackageVersionPublished($PackageId, $PackageVersion)
     return $false
 }
 
-# Parse out package publishing information given a maven CocoaPod spec files
+# Parse out package publishing information given a CocoaPod spec files
 function Get-swift-PackageInfoFromPackageFile ($pkg, $workingDirectory)
 {
     $podspec = Get-Content -Raw -Path $pkg | ConvertFrom-Json

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -10,7 +10,7 @@ function ComputeCocoaPodsSpecUrl($PackageId, $PackageVersion)
     #
     #   Spec/x/y/z/[Package]/[Version]/[Package].podspec.json
     #
-    # The x/y/z values are the first four characters from the MD5 hash of the package name. For example 4/4/a
+    # The x/y/z values are the first three characters from the MD5 hash of the package name. For example 4/4/a
     # for the package AzureCore.
 
     $csp = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
@@ -64,7 +64,7 @@ function Get-swift-PackageInfoFromPackageFile ($pkg, $workingDirectory)
     $podspec = Get-Content -Raw -Path $pkg | ConvertFrom-Json
     $pkgId = $podspec.name
     $pkgVersion = $podspec.version
-    $docsReadMeName = $pkgId -replace "^azure-" , ""
+    $docsReadMeName = $pkgId -replace "^Azure" , ""
     $releaseNotes = ""
     $readmeContent = ""
 

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -1,0 +1,91 @@
+$Language = "swift"
+$LanguageDisplayName = "Swift"
+$PackageRepository = "CocoaPods"
+$packagePattern = "*.podspec.json"
+
+function ComputeCocoaPodsSpecUrl($PackageId, $PackageVersion)
+{
+    # The CocoaPods spec repo is a repository for JSONified versions of the PodSpec file. The path to the JSON
+    # file is derived from the name of the package where the repo URL relative URL is:
+    #
+    #   Spec/x/y/z/[Package]/[Version]/[Package].podspec.json
+    #
+    # The x/y/z values are the first four characters from the MD5 hash of the package name. For example 4/4/a
+    # for the package AzureCore.
+
+    $csp = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
+    $encoder = New-Object -TypeName System.Text.UTF8Encoding
+    $hash = [System.BitConverter]::ToString($csp.ComputeHash($encoder.GetBytes($PackageId)))
+    $hash = $hash.ToLower() -replace '-', ''
+    $url = "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/$($hash[0])/$($hash[1])/$($hash[2])/$PackageId/$PackageVersion/$PackageId.podspec.json"
+    return $url
+}
+
+# Returns the maven (really sonatype) publish status of a package id and version.
+function IsCocoaPodsPackageVersionPublished($PackageId, $PackageVersion)
+{
+    $url = ComputeCocoaPodsSpecUrl -PackageId $PackageId -PackageVersion $PackageVersion
+
+    Write-Host "Checking $url"
+
+    try
+    {
+        $uri = "https://oss.sonatype.org/content/repositories/releases/$groupId/$pkgId/$pkgVersion/$pkgId-$pkgVersion.pom"
+        $podspecContent = Invoke-RestMethod -MaximumRetryCount 3 -RetryIntervalSec 10 -Method "GET" -uri $uri
+
+        if ($podspecContent -ne $null -or $podspecContent.Length -eq 0)
+        {
+        return $true
+        }
+        else
+        {
+        return $false
+        }
+    }
+    catch
+    {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        $statusDescription = $_.Exception.Response.StatusDescription
+
+        # if this is 404ing, then this pkg has never been published before
+        if ($statusCode -eq 404) {
+        return $false
+        }
+
+        Write-Host "VersionCheck to CocoaPods for packageId $PackageId failed with statuscode $statusCode"
+        Write-Host $statusDescription
+        exit(1)
+    }
+    return $false
+}
+
+# Parse out package publishing information given a maven CocoaPod spec files
+function Get-swift-PackageInfoFromPackageFile ($pkg, $workingDirectory)
+{
+    $podspec = Get-Content -Raw -Path $pkg | ConvertFrom-Json
+    $pkgId = $podspec.name
+    $pkgVersion = $podspec.version
+    $docsReadMeName = $pkgId -replace "^azure-" , ""
+    $releaseNotes = ""
+    $readmeContent = ""
+
+    $changeLogLoc = @(Get-ChildItem -Path $pkg.DirectoryName -Recurse -Include "$($pkg.Basename)-changelog.md")[0]
+    if ($changeLogLoc) {
+        $releaseNotes = Get-ChangeLogEntryAsString -ChangeLogLocation $changeLogLoc -VersionString $pkgVersion
+    }
+
+    $readmeContentLoc = @(Get-ChildItem -Path $pkg.DirectoryName -Recurse -Include "$($pkg.Basename)-readme.md")[0]
+    if ($readmeContentLoc) {
+        $readmeContent = Get-Content -Raw $readmeContentLoc
+    }
+
+    return New-Object PSObject -Property @{
+       PackageId      = $pkgId
+       PackageVersion = $pkgVersion
+       ReleaseTag     = "$($pkgId)_$($pkgVersion)"
+       Deployable     = $forceCreate -or !(IsCocoaPodsPackageVersionPublished -PackageId $pkgId -PackageVersion $pkgVersion)
+       ReleaseNotes   = $releaseNotes
+       ReadmeContent  = $readmeContent
+       DocsReadMeName = $docsReadMeName
+    }
+}

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureTemplate",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "summary": "Azure Template Dummy Library",
   "description": "This is a test library for Azure Engineering Systems.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -17,7 +17,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureTemplate_1.0.0"
+    "tag": "AzureTemplate_1.2.0"
   },
   "source_files": "sdk/core/AzureTemplate/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureTemplate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "summary": "Azure Template Dummy Library",
   "description": "This is a test library for Azure Engineering Systems.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",

--- a/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
+++ b/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -406,7 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
+++ b/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -406,7 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/sdk/template/AzureTemplate/CHANGELOG.md
+++ b/sdk/template/AzureTemplate/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Release History
+## 1.1.0
+Azure Template release for Engineering System testing.
 ## 1.0.0
 Azure Template release for Engineering System testing.

--- a/sdk/template/AzureTemplate/CHANGELOG.md
+++ b/sdk/template/AzureTemplate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
-## 1.1.0
+
+# 1.2.0 (Unreleased)
 Azure Template release for Engineering System testing.
-## 1.0.0
+
+## 1.1.0 (2021-05-24)
+Azure Template release for Engineering System testing.
+
+## 1.0.0 (2021-05-21)
 Azure Template release for Engineering System testing.


### PR DESCRIPTION
This PR adds ```Language-Settings.ps1``` which is used by the release tagging logic to detect artifacts that are being published by path. I've validated that this works using ```AzureTemplate```.

Closes #850