### PR TITLE
CocoaPods push support

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -51,7 +51,7 @@ stages:
               - template: ../variables/globals.yml
             pool:
               name: Azure Pipelines
-              vmImage: $(OSVmImage)
+              vmImage: macOS-10.15
             strategy:
               runOnce:
                 deploy:

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -35,12 +35,12 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                      parameters:
-                        ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
-                        PackageRepository: CocoaPods
-                        ReleaseSha: $(Build.SourceVersion)
+                    # - template: /eng/common/pipelines/templates/steps/retain-run.yml
+                    # - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                    #   parameters:
+                    #     ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+                    #     PackageRepository: CocoaPods
+                    #     ReleaseSha: $(Build.SourceVersion)
 
           - deployment: PublishPackageToCocoaPodsTrunk
             displayName: "Publish to CocoaPods Trunk"
@@ -58,8 +58,9 @@ stages:
                   steps:
                     - script: |
                         pod trunk me
-                        pod trunk register midenn@microsoft.com 'Microsoft Corporation' --description='Pipeline Run was: $(Build.BuildID)'
                         pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-moduler-headers
+                      env:
+                        COCOAPODS_TRUNK_TOKEN: $(azure-sdk-cocoapods-trunk-token)
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
             displayName: "Publish to SPM Mirrors"

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -56,9 +56,10 @@ stages:
               runOnce:
                 deploy:
                   steps:
+                    - checkout: self
                     - script: |
                         pod trunk me
-                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}} --synchronous --use-modular-headers
+                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
                       env:
                         COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
                       displayName: Push ${{artifact.name}} to CocoaPods Trunk

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -60,7 +60,7 @@ stages:
                         pod trunk me
                         pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
                       env:
-                        COCOAPODS_TRUNK_TOKEN: $(azure-sdk-cocoapods-trunk-token)
+                        COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
                       displayName: Push ${{artifact.name}} to CocoaPods Trunk
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -35,12 +35,12 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    # - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                    # - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                    #   parameters:
-                    #     ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
-                    #     PackageRepository: CocoaPods
-                    #     ReleaseSha: $(Build.SourceVersion)
+                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
+                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                      parameters:
+                        ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+                        PackageRepository: CocoaPods
+                        ReleaseSha: $(Build.SourceVersion)
 
           - deployment: PublishPackageToCocoaPodsTrunk
             displayName: "Publish to CocoaPods Trunk"

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -58,9 +58,10 @@ stages:
                   steps:
                     - script: |
                         pod trunk me
-                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-moduler-headers
+                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
                       env:
                         COCOAPODS_TRUNK_TOKEN: $(azure-sdk-cocoapods-trunk-token)
+                      displayName: Push ${{artifact.name}} to CocoaPods Trunk
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
             displayName: "Publish to SPM Mirrors"

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -57,7 +57,9 @@ stages:
                 deploy:
                   steps:
                     - script: |
-                        echo "Pretend we are publishing to CocoaPods trunk.""
+                        pod trunk me
+                        pod trunk register midenn@microsoft.com 'Microsoft Corporation' --description='Pipeline Run was: $(Build.BuildID)'
+                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-moduler-headers
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
             displayName: "Publish to SPM Mirrors"

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -58,7 +58,7 @@ stages:
                   steps:
                     - script: |
                         pod trunk me
-                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
+                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}} --synchronous --use-modular-headers
                       env:
                         COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
                       displayName: Push ${{artifact.name}} to CocoaPods Trunk

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -19,7 +19,7 @@
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
     "tag": "AzureTemplate_1.2.0"
   },
-  "source_files": "sdk/core/AzureTemplate/Source/**/*.{swift,h,m}",
+  "source_files": "sdk/template/AzureTemplate/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {
     "DEFINES_MODULE": "YES"
   },

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureTemplate",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "summary": "Azure Template Dummy Library",
   "description": "This is a test library for Azure Engineering Systems.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -17,7 +17,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureTemplate_1.2.0"
+    "tag": "AzureTemplate_1.3.0"
   },
   "source_files": "sdk/template/AzureTemplate/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
+++ b/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -406,7 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/sdk/template/AzureTemplate/CHANGELOG.md
+++ b/sdk/template/AzureTemplate/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
-# 1.2.0 (Unreleased)
+# 1.3.0 (2021-05-26)
+Azure Template release for Engineering System testing.
+
+# 1.2.0 (2021-05-26)
 Azure Template release for Engineering System testing.
 
 ## 1.1.0 (2021-05-24)


### PR DESCRIPTION
This PR adds CocoaPods push support. To authenticate we are making use of the ```COCOAPODS_TRUNK_TOKEN``` environment variable which we'll pull in via a variable group (and ultimately our KeyVault). At this point I don't have the token but once that is available I'll do an end-to-end test, but the error output is what I expect at this point in time.