### PR TITLE
Add SPM publishing to release pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -81,5 +81,5 @@ stages:
                     - checkout: self
                     - checkout: SwiftPM-AzureTemplate
                     - pwsh: |
-                        Get-ChildItem $(Pipeline.Workspace)
+                        Get-ChildItem $(Pipeline.Workspace)\s
                     

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -85,7 +85,7 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/s
                         Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
                         git checkout --orphan run-$(Build.BuildID)
-                        Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}} -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
+                        Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                       displayName: Copy and tag sources
 

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -66,7 +66,7 @@ stages:
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
             displayName: "Publish to SPM Mirrors"
-            condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+            condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'), ne('${{artifact.skipSwiftPackageManager}}', true))
             environment: cocoapodstrunk
             dependsOn: TagRepository
             variables:
@@ -79,7 +79,7 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - checkout: SwiftPM-AzureTemplate
+                    - checkout: SwiftPM-${{artifact.name}}
                       persistCredentials: true
                     - pwsh: |
                         $podspec = Get-Content -Raw -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json | ConvertFrom-Json

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -82,16 +82,17 @@ stages:
                     - checkout: SwiftPM-AzureTemplate
                       persistCredentials: true
                     - pwsh: |
-                        Get-ChildItem $(Pipeline.Workspace)/s
+                        $podspec = Get-Content -Raw -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json | ConvertFrom-Json
+                        $version = $podspec.version
                         Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
-                        git checkout --orphan run-$(Build.BuildID)-temp
+                        git checkout --orphan run-$(Build.BuildID)-temp-branch
                         git reset --hard
                         Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         git add .
-                        git commit -m "Run $(Build.BuildID)"
-                        git tag -a run-$(Build.BuildID) -m "Run $(Build.BuildID)"
-                        git push origin run-$(Build.BuildID)
+                        git commit -m "Releasing: $version"
+                        git tag -a $version -m "$version"
+                        git push origin $version
                       displayName: Copy and tag sources
 
                         

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -21,54 +21,54 @@ stages:
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-java-pr'))
         jobs:
-          # - deployment: TagRepository
-          #   displayName: "Create release tag"
-          #   condition: and(succeeded(), ne(variables['Skip.TagRepository'], 'true'))
-          #   environment: github
-          #   variables:
-          #     - template: ../variables/globals.yml
-          #   pool:
-          #     name: Azure Pipelines
-          #     vmImage: vs2017-win2016
-          #   strategy:
-          #     runOnce:
-          #       deploy:
-          #         steps:
-          #           - checkout: self
-          #           - template: /eng/common/pipelines/templates/steps/retain-run.yml
-          #           - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-          #             parameters:
-          #               ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
-          #               PackageRepository: CocoaPods
-          #               ReleaseSha: $(Build.SourceVersion)
+          - deployment: TagRepository
+            displayName: "Create release tag"
+            condition: and(succeeded(), ne(variables['Skip.TagRepository'], 'true'))
+            environment: github
+            variables:
+              - template: ../variables/globals.yml
+            pool:
+              name: Azure Pipelines
+              vmImage: vs2017-win2016
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: self
+                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
+                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                      parameters:
+                        ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+                        PackageRepository: CocoaPods
+                        ReleaseSha: $(Build.SourceVersion)
 
-          # - deployment: PublishPackageToCocoaPodsTrunk
-          #   displayName: "Publish to CocoaPods Trunk"
-          #   condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-          #   environment: cocoapodstrunk
-          #   dependsOn: TagRepository
-          #   variables:
-          #     - template: ../variables/globals.yml
-          #   pool:
-          #     name: Azure Pipelines
-          #     vmImage: macOS-10.15
-          #   strategy:
-          #     runOnce:
-          #       deploy:
-          #         steps:
-          #           - checkout: self
-          #           - script: |
-          #               pod trunk me
-          #               pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
-          #             env:
-          #               COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
-          #             displayName: Push ${{artifact.name}} to CocoaPods Trunk
+          - deployment: PublishPackageToCocoaPodsTrunk
+            displayName: "Publish to CocoaPods Trunk"
+            condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+            environment: cocoapodstrunk
+            dependsOn: TagRepository
+            variables:
+              - template: ../variables/globals.yml
+            pool:
+              name: Azure Pipelines
+              vmImage: macOS-10.15
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: self
+                    - script: |
+                        pod trunk me
+                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
+                      env:
+                        COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
+                      displayName: Push ${{artifact.name}} to CocoaPods Trunk
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
             displayName: "Publish to SPM Mirrors"
             condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
             environment: cocoapodstrunk
-#            dependsOn: TagRepository
+            dependsOn: TagRepository
             variables:
               - template: ../variables/globals.yml
             pool:

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -81,17 +81,12 @@ stages:
                     - checkout: self
                     - checkout: SwiftPM-${{artifact.name}}
                       persistCredentials: true
-                    - pwsh: |
-                        $podspec = Get-Content -Raw -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json | ConvertFrom-Json
-                        $version = $podspec.version
-                        Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
-                        git checkout --orphan run-$(Build.BuildID)-temp-branch
-                        git reset --hard
-                        Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
-                        git add .
-                        git commit -m "Releasing: $version"
-                        git tag -a $version -m "$version"
-                        git push origin $version
-                      displayName: Copy and tag Swift Package
-                        
-                    
+                    - task: PowerShell@2
+                      displayName: Publish Swift Package
+                      inputs: 
+                        targetType: filePath
+                        filePath: eng/scripts/Publish-SwiftPackage.ps1
+                        arguments: >- 
+                          -GitSourcePath $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+                          -GitDestinationPath $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
+                        pwsh: true                    

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -82,5 +82,4 @@ stages:
                     - checkout: SwiftPM-AzureTemplate
                     - pwsh: |
                         Get-ChildItem $(Pipeline.Workspace)
-                      core: true
                     

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -21,54 +21,54 @@ stages:
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-java-pr'))
         jobs:
-          - deployment: TagRepository
-            displayName: "Create release tag"
-            condition: and(succeeded(), ne(variables['Skip.TagRepository'], 'true'))
-            environment: github
-            variables:
-              - template: ../variables/globals.yml
-            pool:
-              name: Azure Pipelines
-              vmImage: vs2017-win2016
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
-                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                      parameters:
-                        ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
-                        PackageRepository: CocoaPods
-                        ReleaseSha: $(Build.SourceVersion)
+          # - deployment: TagRepository
+          #   displayName: "Create release tag"
+          #   condition: and(succeeded(), ne(variables['Skip.TagRepository'], 'true'))
+          #   environment: github
+          #   variables:
+          #     - template: ../variables/globals.yml
+          #   pool:
+          #     name: Azure Pipelines
+          #     vmImage: vs2017-win2016
+          #   strategy:
+          #     runOnce:
+          #       deploy:
+          #         steps:
+          #           - checkout: self
+          #           - template: /eng/common/pipelines/templates/steps/retain-run.yml
+          #           - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+          #             parameters:
+          #               ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+          #               PackageRepository: CocoaPods
+          #               ReleaseSha: $(Build.SourceVersion)
 
-          - deployment: PublishPackageToCocoaPodsTrunk
-            displayName: "Publish to CocoaPods Trunk"
-            condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
-            environment: cocoapodstrunk
-            dependsOn: TagRepository
-            variables:
-              - template: ../variables/globals.yml
-            pool:
-              name: Azure Pipelines
-              vmImage: macOS-10.15
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
-                    - script: |
-                        pod trunk me
-                        pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
-                      env:
-                        COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
-                      displayName: Push ${{artifact.name}} to CocoaPods Trunk
+          # - deployment: PublishPackageToCocoaPodsTrunk
+          #   displayName: "Publish to CocoaPods Trunk"
+          #   condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+          #   environment: cocoapodstrunk
+          #   dependsOn: TagRepository
+          #   variables:
+          #     - template: ../variables/globals.yml
+          #   pool:
+          #     name: Azure Pipelines
+          #     vmImage: macOS-10.15
+          #   strategy:
+          #     runOnce:
+          #       deploy:
+          #         steps:
+          #           - checkout: self
+          #           - script: |
+          #               pod trunk me
+          #               pod trunk push $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json --synchronous --use-modular-headers
+          #             env:
+          #               COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
+          #             displayName: Push ${{artifact.name}} to CocoaPods Trunk
 
           - deployment: PublishPackageToSwiftPackageManagerMirrors
             displayName: "Publish to SPM Mirrors"
             condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
             environment: cocoapodstrunk
-            dependsOn: TagRepository
+#            dependsOn: TagRepository
             variables:
               - template: ../variables/globals.yml
             pool:
@@ -78,5 +78,7 @@ stages:
               runOnce:
                 deploy:
                   steps:
+                    - checkout: self
+                    - checkout: SwiftPM-AzureTemplate
                     - script: |
                         echo "Pretend we are publishing to Swift Package Manager mirrors"

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -85,8 +85,13 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/s
                         Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
                         git checkout --orphan run-$(Build.BuildID)
+                        git reset --hard
                         Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
+                        git add .
+                        git commit -m "Run $(Build.BuildID}"
+                        git tag -a run-$(Build.BuildID) -m "Run $(Build.BuildID)"
+                        git push origin run-$(Build.BuildID)
                       displayName: Copy and tag sources
 
                         

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -85,7 +85,7 @@ stages:
                       displayName: Publish Swift Package
                       inputs: 
                         targetType: filePath
-                        filePath: eng/scripts/Publish-SwiftPackage.ps1
+                        filePath: azure-sdk-for-ios/eng/scripts/Publish-SwiftPackage.ps1
                         arguments: >- 
                           -GitSourcePath $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
                           -GitDestinationPath $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -88,12 +88,10 @@ stages:
                         git checkout --orphan run-$(Build.BuildID)-temp-branch
                         git reset --hard
                         Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
-                        Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         git add .
                         git commit -m "Releasing: $version"
                         git tag -a $version -m "$version"
                         git push origin $version
-                      displayName: Copy and tag sources
-
+                      displayName: Copy and tag Swift Package
                         
                     

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -68,7 +68,7 @@ stages:
             displayName: "Publish to SPM Mirrors"
             condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'), ne('${{artifact.skipSwiftPackageManager}}', true))
             environment: cocoapodstrunk
-            dependsOn: TagRepository
+            dependsOn: PublishPackageToCocoaPodsTrunk
             variables:
               - template: ../variables/globals.yml
             pool:

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -89,7 +89,7 @@ stages:
                         Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         git add .
-                        git commit -m "Run $(Build.BuildID}"
+                        git commit -m "Run $(Build.BuildID)"
                         git tag -a run-$(Build.BuildID) -m "Run $(Build.BuildID)"
                         git push origin run-$(Build.BuildID)
                       displayName: Copy and tag sources

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -80,7 +80,14 @@ stages:
                   steps:
                     - checkout: self
                     - checkout: SwiftPM-AzureTemplate
-                      preserveCredentials: true
+                      persistCredentials: true
                     - pwsh: |
-                        Get-ChildItem $(Pipeline.Workspace)\s
+                        Get-ChildItem $(Pipeline.Workspace)/s
+                        Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
+                        git checkout --orphan run-$(Build.BuildID)
+                        Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}} -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
+                        Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
+                      displayName: Copy and tag sources
+
+                        
                     

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -72,13 +72,15 @@ stages:
             variables:
               - template: ../variables/globals.yml
             pool:
-              name: Azure Pipelines
-              vmImage: $(OSVmImage)
+              name: azsdk-pool-mms-ubuntu-1804-general
+              vmImage: MMSUbuntu18.04
             strategy:
               runOnce:
                 deploy:
                   steps:
                     - checkout: self
                     - checkout: SwiftPM-AzureTemplate
-                    - script: |
-                        echo "Pretend we are publishing to Swift Package Manager mirrors"
+                    - pwsh: |
+                        Get-ChildItem $(Pipeline.Workspace)
+                      core: true
+                    

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -84,7 +84,7 @@ stages:
                     - pwsh: |
                         Get-ChildItem $(Pipeline.Workspace)/s
                         Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
-                        git checkout --orphan run-$(Build.BuildID)
+                        git checkout --orphan run-$(Build.BuildID)-temp
                         git reset --hard
                         Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
                         Get-ChildItem -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -80,6 +80,7 @@ stages:
                   steps:
                     - checkout: self
                     - checkout: SwiftPM-AzureTemplate
+                      preserveCredentials: true
                     - pwsh: |
                         Get-ChildItem $(Pipeline.Workspace)\s
                     

--- a/eng/scripts/Publish-SwiftPackage.ps1
+++ b/eng/scripts/Publish-SwiftPackage.ps1
@@ -1,0 +1,69 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $GitSourcePath,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $GitDestinationPath
+)
+
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot/../common/scripts common.ps1)
+
+try {
+
+    Push-Location -Path $GitDestinationPath
+    
+    LogDebug "Searching for *.podspec.json files in: $GitSourcePath"
+    $podspecFiles = Get-ChildItem -Path $GitSourcePath -Filter *.podspec.json
+    LogDebug "Found $($podspecFiles.Count) *.podspec.json files in: $GitSourcePath"
+    
+    if ($podspecFiles.Count -ne 1) {
+        throw "The path $GitSourcePath must contain one, and only one *.podspec.json file."
+    }
+    
+    LogDebug "Parsing $($podspecFiles[0].Name)"
+    $podspec = Get-Content -Raw -Path $podspecFiles[0] | ConvertFrom-Json
+    $name = $podspec.name
+    $version = $podspec.version
+    
+    LogDebug "Publishing: $name@$version"
+    
+    
+    $orphanBranchName = [Guid]::NewGuid()
+    LogDebug "Checking out orphan branch: $orphanBranchName"
+    git checkout --orphan $orphanBranchName
+    git reset --hard
+    
+    LogDebug "Copying package to orphan branch"
+    Copy-Item -Path $GitSourcePath/* -Destination $GitDestinationPath -Recurse
+    
+    LogDebug "Committing files to branch"
+    git add .
+    git commit -m "Releasing $version"
+    
+    LogDebug "Tagging and pushing version: $version"
+    git tag -a $version -m "$version"
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to tag repository because tag $version already exists!"
+    }
+
+    git push origin $version
+    
+    # $podspec = Get-Content -Raw -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json | ConvertFrom-Json
+    # $version = $podspec.version
+    # Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
+    # git checkout --orphan run-$(Build.BuildID)-temp-branch
+    # git reset --hard
+    # Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
+    # git add .
+    # git commit -m "Releasing: $version"
+    # git tag -a $version -m "$version"
+    # git push origin $version
+}
+finally {
+    Pop-Location
+}

--- a/eng/scripts/Publish-SwiftPackage.ps1
+++ b/eng/scripts/Publish-SwiftPackage.ps1
@@ -52,17 +52,6 @@ try {
     }
 
     git push origin $version
-    
-    # $podspec = Get-Content -Raw -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/${{artifact.name}}.podspec.json | ConvertFrom-Json
-    # $version = $podspec.version
-    # Push-Location -Path $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
-    # git checkout --orphan run-$(Build.BuildID)-temp-branch
-    # git reset --hard
-    # Copy-Item -Path $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/* -Destination $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}} -Recurse
-    # git add .
-    # git commit -m "Releasing: $version"
-    # git tag -a $version -m "$version"
-    # git push origin $version
 }
 finally {
     Pop-Location

--- a/sdk/communication/ci.yml
+++ b/sdk/communication/ci.yml
@@ -22,6 +22,16 @@ pr:
     - sdk/communication/
     - sdk/eng/
 
+resources:
+  repositories:
+  - repository: SwiftPM-AzureCommunicationCommon
+    type: github
+    name: Azure/SwiftPM-AzureCommunicationCommon
+    endpoint: Azure
+  - repository: SwiftPM-AzureCommunicationChat
+    type: github
+    name: Azure/SwiftPM-AzureCommunicationChat
+    endpoint: Azure
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -31,3 +41,4 @@ extends:
     - name: AzureCommunicationCommon
     - name: AzureCommunicationChat
     - name: AzureCommunicationCalling
+      skipSwiftPackageManager: true

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -22,6 +22,12 @@ pr:
     - sdk/core/
     - sdk/eng/
 
+resources:
+  repositories:
+  - repository: SwiftPM-AzureCore
+    type: github
+    name: Azure/SwiftPM-AzureCore
+    endpoint: Azure
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -22,16 +22,10 @@ pr:
     - sdk/identity/
     - sdk/eng/
 
-resources:
-  repositories:
-  - repository: SwiftPM-AzureIdentity
-    type: github
-    name: Azure/SwiftPM-AzureIdentity
-    endpoint: Azure
-
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: identity
     Artifacts:
     - name: AzureIdentity
+      skipSwiftPackageManager: true

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -22,6 +22,12 @@ pr:
     - sdk/identity/
     - sdk/eng/
 
+resources:
+  repositories:
+  - repository: SwiftPM-AzureIdentity
+    type: github
+    name: Azure/SwiftPM-AzureIdentity
+    endpoint: Azure
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -22,6 +22,13 @@ pr:
     - sdk/storage/
     - sdk/eng/
 
+resources:
+  repositories:
+  - repository: SwiftPM-AzureStorageBlob
+    type: github
+    name: Azure/SwiftPM-AzureStorageBlob
+    endpoint: Azure
+
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -22,16 +22,10 @@ pr:
     - sdk/storage/
     - sdk/eng/
 
-resources:
-  repositories:
-  - repository: SwiftPM-AzureStorageBlob
-    type: github
-    name: Azure/SwiftPM-AzureStorageBlob
-    endpoint: Azure
-
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: storage
     Artifacts:
     - name: AzureStorageBlob
+      skipSwiftPackageManager: true

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureTemplate",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "summary": "Azure Template Dummy Library",
   "description": "This is a test library for Azure Engineering Systems.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -17,7 +17,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureTemplate_1.3.0"
+    "tag": "AzureTemplate_1.4.0"
   },
   "source_files": "sdk/template/AzureTemplate/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureTemplate",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "summary": "Azure Template Dummy Library",
   "description": "This is a test library for Azure Engineering Systems.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -17,7 +17,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureTemplate_1.5.0"
+    "tag": "AzureTemplate_1.6.0"
   },
   "source_files": "sdk/template/AzureTemplate/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/template/AzureTemplate/AzureTemplate.podspec.json
+++ b/sdk/template/AzureTemplate/AzureTemplate.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureTemplate",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "summary": "Azure Template Dummy Library",
   "description": "This is a test library for Azure Engineering Systems.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -17,7 +17,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureTemplate_1.4.0"
+    "tag": "AzureTemplate_1.5.0"
   },
   "source_files": "sdk/template/AzureTemplate/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
+++ b/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -406,7 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
+++ b/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -406,7 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
+++ b/sdk/template/AzureTemplate/AzureTemplate.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -406,7 +406,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -26,7 +26,7 @@ resources:
   repositories:
   - repository: SwiftPM-AzureTemplate
     type: github
-    name: Azure/SwiftPM-AzureCore
+    name: Azure/SwiftPM-AzureTemplate
     endpoint: Azure
 
 extends:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -22,6 +22,12 @@ pr:
     - sdk/template/
     - sdk/eng/
 
+resources:
+  repositories:
+  - repository: SwiftPM-AzureTemplate
+    type: github
+    name: Azure/SwiftPM-AzureCore
+
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -27,6 +27,7 @@ resources:
   - repository: SwiftPM-AzureTemplate
     type: github
     name: Azure/SwiftPM-AzureCore
+    endpoint: Azure
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
An initial pass at publishing SPM packages via the release pipeline. It requires that we add a repository resource (or two) to each individual pipeline. Then during this job we clone the mono-repo, and the ```SwiftPM-[packagename]``` repo. We then checkout an orphan branch and copy the files over, commit, tag and then push (tag only).

In cases where a package doesn't support SPM (e.g. ```AzureCommunicationCalling```), we just don't emit that job.