### PR TITLE
Release AzureCommunicationChat 1.0.0-beta.12

### DIFF
--- a/examples/AzureSDKSmokeTest/AzureSDKSmokeTest/AppDelegate.swift
+++ b/examples/AzureSDKSmokeTest/AzureSDKSmokeTest/AppDelegate.swift
@@ -27,10 +27,10 @@
 import UIKit
 
 import AzureCommunicationCalling
+import AzureCommunicationChat
 import AzureCommunicationCommon
 // Import all relevant, released SDKs here
 import AzureCore
-// import AzureCommunicationChat
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/examples/AzureSDKSmokeTest/Podfile
+++ b/examples/AzureSDKSmokeTest/Podfile
@@ -48,13 +48,13 @@ target 'AzureSDKSmokeTest' do
     # install podspecs locally from source branch/PR
     pod 'AzureCore', :podspec => "#{local_path}/sdk/core/AzureCore/AzureCore.podspec.json"
     pod 'AzureCommunicationCommon', :podspec => "#{local_path}/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json"
-    #pod 'AzureCommunicationChat', :podspec => "#{local_path}/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json"
+    pod 'AzureCommunicationChat', :podspec => "#{local_path}/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json"
     pod 'AzureCommunicationCalling', :podspec => "#{local_path}/sdk/communication/AzureCommunicationCalling/AzureCommunicationCalling.podspec.json"
   else
     # manual run targets AzureSDK branch
     pod 'AzureCore', :podspec => "https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/#{branch}/sdk/core/AzureCore/AzureCore.podspec.json"
     pod 'AzureCommunicationCommon', :podspec => "https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/#{branch}/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json"
-    #pod 'AzureCommunicationChat', :podspec => "https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/#{branch}/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json"
+    pod 'AzureCommunicationChat', :podspec => "https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/#{branch}/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json"
     pod 'AzureCommunicationCalling', :podspec => "https://raw.githubusercontent.com/Azure/azure-sdk-for-ios/#{branch}/sdk/communication/AzureCommunicationCalling/AzureCommunicationCalling.podspec.json"
   end
 end

--- a/jazzy/AzureCommunicationChat.yml
+++ b/jazzy/AzureCommunicationChat.yml
@@ -2,7 +2,7 @@ author: Microsoft
 author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure/azure-sdk-for-ios
 module: AzureCommunicationChat
-module_version: 1.0.0-beta.11
+module_version: 1.0.0-beta.12
 readme: ../sdk/communication/AzureCommunicationChat/README.md
 skip_undocumented: false
 hide_unlisted_documentation: false

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "1.0.0-beta.12"
+    "tag": "AzureCommunicationChat_1.0.0-beta.12"
   },
   "source_files": "sdk/communication/AzureCommunicationChat/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCommunicationChat",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "summary": "Azure Communication Chat Service client library for iOS",
   "description": "This package contains the Chat client library for Azure Communication\nServices.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "1.0.0-beta.11"
+    "tag": "1.0.0-beta.12"
   },
   "source_files": "sdk/communication/AzureCommunicationChat/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
@@ -1091,7 +1091,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-beta.11";
+				MARKETING_VERSION = "1.0.0-beta.12";
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationChat;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1124,7 +1124,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-beta.11";
+				MARKETING_VERSION = "1.0.0-beta.12";
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationChat;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/sdk/communication/AzureCommunicationChat/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationChat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (Unreleased)
+## 1.0.0-beta.12 (Unreleased)
 ### Breaking Changes
 - Changed the way in which options are instantiated for the following classes: `CreateChatThreadOptions`, `DeleteChatThreadOptions`,  `ListChatThreadsOptions`, `AddChatParticipantsOptions`, `DeleteChatMessageOptions`, `GetChatMessageOptions`, `GetChatThreadPropertiesOptions`, `ListChatMessagesOptions`, `ListChatParticipantsOptions`, `ListChatReadReceiptsOptions`, `RemoveChatParticipantOptions`, `SendChatMessageOptions`, `SendChatReadReceiptOptions`, `SendTypingNotificationOptions`, `UpdateChatMessageOptions`, `UpdateChatThreadPropertiesOptions`.
     - old:

--- a/sdk/communication/AzureCommunicationChat/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationChat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.12 (Unreleased)
+## 1.0.0-beta.12 (2021-06-07)
 ### Breaking Changes
 - Changed the way in which options are instantiated for the following classes: `CreateChatThreadOptions`, `DeleteChatThreadOptions`,  `ListChatThreadsOptions`, `AddChatParticipantsOptions`, `DeleteChatMessageOptions`, `GetChatMessageOptions`, `GetChatThreadPropertiesOptions`, `ListChatMessagesOptions`, `ListChatParticipantsOptions`, `ListChatReadReceiptsOptions`, `RemoveChatParticipantOptions`, `SendChatMessageOptions`, `SendChatReadReceiptOptions`, `SendTypingNotificationOptions`, `UpdateChatMessageOptions`, `UpdateChatThreadPropertiesOptions`.
     - old:

--- a/sdk/communication/AzureCommunicationChat/README.md
+++ b/sdk/communication/AzureCommunicationChat/README.md
@@ -54,7 +54,7 @@ specifying the clone URL of this repository and the version specifier you wish t
 // swift-tools-version:5.3
     dependencies: [
         ...
-        .package(name: "AzureCommunicationChat", url: "https://github.com/Azure/SwiftPM-AzureCommunicationChat.git", from: "1.0.0-beta.11")
+        .package(name: "AzureCommunicationChat", url: "https://github.com/Azure/SwiftPM-AzureCommunicationChat.git", from: "1.0.0-beta.12")
     ],
 ```
 
@@ -92,7 +92,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'MyTarget' do
-  pod 'AzureCommunicationChat', '1.0.0-beta.11'
+  pod 'AzureCommunicationChat', '1.0.0-beta.12'
   ...
 end
 ```


### PR DESCRIPTION
Bumps AzureCore dependency to 1.0.0-beta.12 for compatibility withe the latest version of AzureCommunicationCalling.