### PR TITLE
Fix duplication release stage name

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -16,7 +16,7 @@ stages:
   # pipeline completes.
   - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
-      - stage: Release_${{artifact.safeName}}
+      - stage: Release_${{artifact.name}}
         displayName: 'Release: ${{artifact.name}}'
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-java-pr'))


### PR DESCRIPTION
Queuing release pipelines for Azure Communication is failing because the the release stage YAML incorrectly references ```safeName``` for the stage name. Unfortunately this value isn't present and so in pipelines with more than one artifact, the release stage names end up being duplicated in the resulting YAML which is an error. This should fix that up.