### PR TITLE
Fix communications release pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -63,30 +63,30 @@ stages:
                       env:
                         COCOAPODS_TRUNK_TOKEN: $(azuresdk-cocoapods-trunk-token)
                       displayName: Push ${{artifact.name}} to CocoaPods Trunk
-
-          - deployment: PublishPackageToSwiftPackageManagerMirrors
-            displayName: "Publish to SPM Mirrors"
-            condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'), ne('${{artifact.skipSwiftPackageManager}}', true))
-            environment: cocoapodstrunk
-            dependsOn: PublishPackageToCocoaPodsTrunk
-            variables:
-              - template: ../variables/globals.yml
-            pool:
-              name: azsdk-pool-mms-ubuntu-1804-general
-              vmImage: MMSUbuntu18.04
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
-                    - checkout: SwiftPM-${{artifact.name}}
-                      persistCredentials: true
-                    - task: PowerShell@2
-                      displayName: Publish Swift Package
-                      inputs: 
-                        targetType: filePath
-                        filePath: azure-sdk-for-ios/eng/scripts/Publish-SwiftPackage.ps1
-                        arguments: >- 
-                          -GitSourcePath $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
-                          -GitDestinationPath $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
-                        pwsh: true                    
+          - ${{if ne(artifact.skipSwiftPackageManager, 'true')}}:
+            - deployment: PublishPackageToSwiftPackageManagerMirrors
+              displayName: "Publish to SPM Mirrors"
+              condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+              environment: cocoapodstrunk
+              dependsOn: PublishPackageToCocoaPodsTrunk
+              variables:
+                - template: ../variables/globals.yml
+              pool:
+                name: azsdk-pool-mms-ubuntu-1804-general
+                vmImage: MMSUbuntu18.04
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: self
+                      - checkout: SwiftPM-${{artifact.name}}
+                        persistCredentials: true
+                      - task: PowerShell@2
+                        displayName: Publish Swift Package
+                        inputs: 
+                          targetType: filePath
+                          filePath: azure-sdk-for-ios/eng/scripts/Publish-SwiftPackage.ps1
+                          arguments: >- 
+                            -GitSourcePath $(Pipeline.Workspace)/s/azure-sdk-for-ios/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
+                            -GitDestinationPath $(Pipeline.Workspace)/s/SwiftPM-${{artifact.name}}
+                          pwsh: true                    

--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -16,7 +16,7 @@ stages:
   # pipeline completes.
   - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
-      - stage: Release_${{artifact.safeName}}
+      - stage: Release_${{artifact.name}}
         displayName: 'Release: ${{artifact.name}}'
         dependsOn: ${{parameters.DependsOn}}
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-java-pr'))


### PR DESCRIPTION
This PR fixes the broken communications release pipeline. It was breaking because even though the release stage for SPM was behind a condition, the YAML itself was still invalid (the ```checkout:```). To fix it I moved to using a template ```{{if ...}}``` condition which omits the entire job from the generated YAML.