### PR TITLE
Update DVR references to point to fork rather than venmo

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -44,7 +44,7 @@ target 'AzureCommunicationChat' do
     inherit! :search_paths
     pod 'OHHTTPStubs/Swift'
     pod 'TrouterClientIos', '0.0.1-beta.4'
-    pod 'DVR', '~>2.0.0'
+    pod 'DVR', :git => 'https://github.com/tjprescott/DVR.git', :branch => 'main'
   end
   
   target 'AzureCommunicationChatUnitTests' do
@@ -108,6 +108,6 @@ end
 
 target 'AzureTest' do
   project 'sdk/test/AzureTest/AzureTest'
-  pod 'DVR', '~>2.0.0'
+  pod 'DVR', :git => 'https://github.com/tjprescott/DVR.git', :branch => 'main'
 end
 

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0A1E75922670030A00054F60 /* DVR in Frameworks */ = {isa = PBXBuildFile; productRef = 0A1E75912670030A00054F60 /* DVR */; };
 		0A1E7594267003A000054F60 /* ChatClientDVRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E7593267003A000054F60 /* ChatClientDVRTests.swift */; };
 		0A1E759A26700C1E00054F60 /* AzureTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A1E75972670077800054F60 /* AzureTest.framework */; };
 		0A68BF762656EED6004A7E3D /* ChatError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A68BF752656EED6004A7E3D /* ChatError.swift */; };
@@ -38,7 +37,6 @@
 		88D37B9025D60CCD004F3699 /* CommunicationUserIdentifierModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D37B8C25D60CCD004F3699 /* CommunicationUserIdentifierModel.swift */; };
 		88D37B9125D60CCD004F3699 /* PhoneNumberIdentifierModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D37B8D25D60CCD004F3699 /* PhoneNumberIdentifierModel.swift */; };
 		88F361162630EB7200A895D1 /* AzureCommunicationCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88F361152630EB7200A895D1 /* AzureCommunicationCommon.framework */; };
-		88F361172630EB7200A895D1 /* AzureCommunicationCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 88F361152630EB7200A895D1 /* AzureCommunicationCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9766BE9261FCB48436FA6682 /* Pods_AzureCommunicationChatTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1FE3013E797A134E8A6C3B5 /* Pods_AzureCommunicationChatTests.framework */; };
 		D10458A725EEA47800B3EB6D /* CommunicationSignalingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A125EEA47800B3EB6D /* CommunicationSignalingClient.swift */; };
 		D10458A825EEA47800B3EB6D /* TrouterEventUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10458A225EEA47800B3EB6D /* TrouterEventUtil.swift */; };
@@ -136,20 +134,6 @@
 			remoteInfo = AzureCommunicationChat;
 		};
 /* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		88F361182630EB7200A895D1 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				88F361172630EB7200A895D1 /* AzureCommunicationCommon.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		04B336EEF1E42CCE389E4935 /* Pods-AzureCommunicationChat.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureCommunicationChat.release.xcconfig"; path = "Target Support Files/Pods-AzureCommunicationChat/Pods-AzureCommunicationChat.release.xcconfig"; sourceTree = "<group>"; };
@@ -303,7 +287,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				0A1E75922670030A00054F60 /* DVR in Frameworks */,
 				D110F50A258D604B001FA3CD /* AzureCore.framework in Frameworks */,
 				0A1E759A26700C1E00054F60 /* AzureTest.framework in Frameworks */,
 				88F361162630EB7200A895D1 /* AzureCommunicationCommon.framework in Frameworks */,
@@ -601,7 +584,6 @@
 				OBJ_120 /* Sources */,
 				OBJ_161 /* Frameworks */,
 				0ADDCFDA258D2AA900BD5E58 /* Format and Lint */,
-				88F361182630EB7200A895D1 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -610,7 +592,6 @@
 			name = AzureCommunicationChat;
 			packageProductDependencies = (
 				8821443E261388A700040B91 /* TrouterClientIos */,
-				0A1E75912670030A00054F60 /* DVR */,
 			);
 			productName = AzureCommunicationChat;
 			productReference = "AzureCommunicationChat::AzureCommunicationChat::Product" /* AzureCommunicationChat.framework */;
@@ -693,7 +674,6 @@
 			packageReferences = (
 				D1BA104B25807B7500CA7130 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
 				8821443D261388A700040B91 /* XCRemoteSwiftPackageReference "trouter-client-ios" */,
-				0A1E75902670030A00054F60 /* XCRemoteSwiftPackageReference "DVR" */,
 			);
 			productRefGroup = OBJ_113 /* Products */;
 			projectDirPath = "";
@@ -1316,14 +1296,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0A1E75902670030A00054F60 /* XCRemoteSwiftPackageReference "DVR" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/venmo/DVR";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.1.0;
-			};
-		};
 		8821443D261388A700040B91 /* XCRemoteSwiftPackageReference "trouter-client-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/microsoft/trouter-client-ios/";
@@ -1343,11 +1315,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0A1E75912670030A00054F60 /* DVR */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0A1E75902670030A00054F60 /* XCRemoteSwiftPackageReference "DVR" */;
-			productName = DVR;
-		};
 		8821443E261388A700040B91 /* TrouterClientIos */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8821443D261388A700040B91 /* XCRemoteSwiftPackageReference "trouter-client-ios" */;

--- a/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
@@ -75,7 +75,6 @@ class ChatClientDVRTests: XCTestCase {
                 XCTFail("Create thread failed with error: \(error)")
             }
             expectation.fulfill()
-
         }
 
         waitForExpectations(timeout: 10.0) { error in

--- a/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
@@ -56,34 +56,34 @@ class ChatClientDVRTests: XCTestCase {
         transport?.close()
     }
 
-//    func test_CreateThread_WithoutParticipants() {
-//        let thread = CreateChatThreadRequest(
-//            topic: "Test topic"
-//        )
-//
-//        let expectation = self.expectation(description: "Create thread")
-//
-//        chatClient.create(thread: thread) { result, httpResponse in
-//            switch result {
-//            case let .success(response):
-//                let chatThread = response.chatThread
-//                XCTAssertNotNil(response.chatThread)
-//                XCTAssertEqual(chatThread?.topic, thread.topic)
-//                XCTAssertNotNil(httpResponse?.httpRequest?.headers["repeatability-request-id"])
-//                XCTAssertNil(response.invalidParticipants)
-//            case let .failure(error):
-//                XCTFail("Create thread failed with error: \(error)")
-//            }
-//            expectation.fulfill()
-//
-//        }
-//
-//        waitForExpectations(timeout: 10.0) { error in
-//            if let error = error {
-//                XCTFail("Create thread timed out: \(error)")
-//            }
-//        }
-//    }
+    func test_CreateThread_WithoutParticipants() {
+        let thread = CreateChatThreadRequest(
+            topic: "Test topic"
+        )
+
+        let expectation = self.expectation(description: "Create thread")
+
+        chatClient.create(thread: thread) { result, httpResponse in
+            switch result {
+            case let .success(response):
+                let chatThread = response.chatThread
+                XCTAssertNotNil(response.chatThread)
+                XCTAssertEqual(chatThread?.topic, thread.topic)
+                XCTAssertNotNil(httpResponse?.httpRequest?.headers["repeatability-request-id"])
+                XCTAssertNil(response.invalidParticipants)
+            case let .failure(error):
+                XCTFail("Create thread failed with error: \(error)")
+            }
+            expectation.fulfill()
+
+        }
+
+        waitForExpectations(timeout: 10.0) { error in
+            if let error = error {
+                XCTFail("Create thread timed out: \(error)")
+            }
+        }
+    }
 
     func test_ListThreads_ReturnsChatThreadItems() {
         let expectation = self.expectation(description: "List threads")

--- a/sdk/test/AzureTest/AzureTest.xcodeproj/project.pbxproj
+++ b/sdk/test/AzureTest/AzureTest.xcodeproj/project.pbxproj
@@ -3,16 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0A1E758F266FFC9600054F60 /* DVR in Frameworks */ = {isa = PBXBuildFile; productRef = 0A1E758E266FFC9600054F60 /* DVR */; };
 		0A1E75962670053100054F60 /* DVRSessionTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E75952670053100054F60 /* DVRSessionTransport.swift */; };
 		0A1E759E2671386500054F60 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E759D2671386500054F60 /* Util.swift */; };
 		0A2097BA266FCE7D00FE2272 /* ResourceUtilityClientOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2097B9266FCE7D00FE2272 /* ResourceUtilityClientOptions.swift */; };
 		0A2097BF266FDF0000FE2272 /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A2097BB266FDE0200FE2272 /* AzureCore.framework */; };
-		0A2097C0266FDF0000FE2272 /* AzureCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0A2097BB266FDE0200FE2272 /* AzureCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7A2B1CBFB1B422A725A8C01B /* Pods_AzureTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63223FEC2B266A9E151BF760 /* Pods_AzureTest.framework */; };
 		OBJ_22 /* ResourceUtilityClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* ResourceUtilityClient.swift */; };
 		OBJ_40 /* AzureTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* AzureTestTests.swift */; };
@@ -28,20 +26,6 @@
 			remoteInfo = AzureTest;
 		};
 /* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		0A2097C1266FDF0000FE2272 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				0A2097C0266FDF0000FE2272 /* AzureCore.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0A1E75952670053100054F60 /* DVRSessionTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVRSessionTransport.swift; sourceTree = "<group>"; };
@@ -67,7 +51,6 @@
 			files = (
 				7A2B1CBFB1B422A725A8C01B /* Pods_AzureTest.framework in Frameworks */,
 				0A2097BF266FDF0000FE2272 /* AzureCore.framework in Frameworks */,
-				0A1E758F266FFC9600054F60 /* DVR in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -153,7 +136,6 @@
 				36DA6D3F6489BCC66BB4718A /* [CP] Check Pods Manifest.lock */,
 				OBJ_21 /* Sources */,
 				OBJ_23 /* Frameworks */,
-				0A2097C1266FDF0000FE2272 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -161,7 +143,6 @@
 			);
 			name = AzureTest;
 			packageProductDependencies = (
-				0A1E758E266FFC9600054F60 /* DVR */,
 			);
 			productName = AzureTest;
 			productReference = "AzureTest::AzureTest::Product" /* AzureTest.framework */;
@@ -202,7 +183,6 @@
 			);
 			mainGroup = OBJ_5;
 			packageReferences = (
-				0A1E758D266FFC9600054F60 /* XCRemoteSwiftPackageReference "DVR" */,
 			);
 			productRefGroup = OBJ_13 /* Products */;
 			projectDirPath = "";
@@ -283,10 +263,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AzureTest.xcodeproj/AzureTest_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -316,10 +293,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AzureTest.xcodeproj/AzureTest_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -378,11 +352,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AzureTest.xcodeproj/AzureTestTests_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@loader_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -408,11 +378,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AzureTest.xcodeproj/AzureTestTests_Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@loader_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -446,8 +412,7 @@
 				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
@@ -483,25 +448,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		0A1E758D266FFC9600054F60 /* XCRemoteSwiftPackageReference "DVR" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/venmo/DVR";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		0A1E758E266FFC9600054F60 /* DVR */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0A1E758D266FFC9600054F60 /* XCRemoteSwiftPackageReference "DVR" */;
-			productName = DVR;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = OBJ_1 /* Project object */;
 }

--- a/sdk/test/AzureTest/Package.swift
+++ b/sdk/test/AzureTest/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "AzureCore", url: "https://github.com/Azure/SwiftPM-AzureCore.git", from: "1.0.0-beta.12"),
-        .package(name: "DVR", url: "https://github.com/venmo/DVR.git", from: "2.0.0")
+        .package(name: "DVR", url: "https://github.com/tjprescott/DVR.git", .branch: "main")
     ],
     targets: [
         // Build targets


### PR DESCRIPTION
By pointing to our fork, we can iterate more quickly on issues that arise with DVR.