### PR TITLE
Fix (os/kern) invalid host bug

### DIFF
--- a/sdk/communication/AzureCommunicationChat/Tests/test-settings.plist
+++ b/sdk/communication/AzureCommunicationChat/Tests/test-settings.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>endpoint</key>
+	<string></string>
+	<key>user1</key>
+	<string></string>
+	<key>user2</key>
+	<string></string>
+	<key>token</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
This was caused, as best I can tell, by a blank environment variable key/value in the AzureCommunicationChat scheme. Removing this empty variable fixed the issue for me. 