### PR TITLE
ChatClient set default applicationId to empty string + add missing signaling init step

### DIFF
--- a/sdk/communication/AzureCommunicationChat/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationChat/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1
+## 1.0.1 (2021-07-23)
 ### New Features
 - ChatClient sets `applicationId` to be empty by default instead of using the bundle identifier
 

--- a/sdk/communication/AzureCommunicationChat/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationChat/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 1.0.0
+## 1.0.1
+### New Features
+- ChatClient sets `applicationId` to be empty by default instead of using the bundle identifier
+
+## 1.0.0 (2021-07-20)
 ### Breaking Changes
 - Update message parameters updated to `update(message: String, parameters: UpdateChatMessageRequest)`
 - `EventHandler` renamed to `TrouterEventHandler`

--- a/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
@@ -59,13 +59,32 @@ public class ChatClient {
             throw AzureError.client("Unable to form base URL.")
         }
 
+        // If applicationId is not provided bundle identifier will be used
+        // Instead set the default application id to be an empty string
+        var updatedOptions: AzureCommunicationChatClientOptions?
+        if options.telemetryOptions.applicationId == nil {
+            let apiVersion = AzureCommunicationChatClientOptions.ApiVersion(options.apiVersion)
+            let telemetryOptions = TelemetryOptions(
+                telemetryDisabled: options.telemetryOptions.telemetryDisabled,
+                applicationId: ""
+            )
+
+            updatedOptions = AzureCommunicationChatClientOptions(
+                apiVersion: apiVersion,
+                logger: options.logger,
+                telemetryOptions: telemetryOptions,
+                transportOptions: options.transportOptions,
+                dispatchQueue: options.dispatchQueue
+            )
+        }
+
         let communicationCredential = TokenCredentialAdapter(credential)
         let authPolicy = BearerTokenCredentialPolicy(credential: communicationCredential, scopes: [])
 
         let client = try ChatClientInternal(
             endpoint: endpointUrl,
             authPolicy: authPolicy,
-            withOptions: options
+            withOptions: updatedOptions ?? options
         )
 
         self.service = client.chat

--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/CommunicationSignalingClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/CommunicationSignalingClient.swift
@@ -79,6 +79,7 @@ class CommunicationSignalingClient {
     func start() {
         selfHostedTrouterClient.withRegistrar(trouterUrlRegistrar)
         selfHostedTrouterClient.start()
+        selfHostedTrouterClient.setUserActivityState(UserActivityState.TrouterUserActivityStateActive)
     }
 
     func stop() {


### PR DESCRIPTION
- applicationId should be empty by default instead of the bundle identifier
- add missing trouter call to set activity state