### PR TITLE
Ensure RecordableXCTestCase tests will be run on CI

### DIFF
--- a/AzureSDK.xcworkspace/xcshareddata/xcschemes/communication.xcscheme
+++ b/AzureSDK.xcworkspace/xcshareddata/xcschemes/communication.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1230"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -94,6 +94,10 @@
                BlueprintName = "AzureCommunicationChatTests"
                ReferencedContainer = "container:sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj">
             </BuildableReference>
+            <LocationScenarioReference
+               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+               referenceType = "1">
+            </LocationScenarioReference>
          </TestableReference>
          <TestableReference
             skipped = "NO">
@@ -104,6 +108,10 @@
                BlueprintName = "AzureCommunicationChatUnitTests"
                ReferencedContainer = "container:sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj">
             </BuildableReference>
+            <LocationScenarioReference
+               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+               referenceType = "1">
+            </LocationScenarioReference>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/AzureSDK.xcworkspace/xcshareddata/xcschemes/sdk.xcscheme
+++ b/AzureSDK.xcworkspace/xcshareddata/xcschemes/sdk.xcscheme
@@ -114,8 +114,7 @@
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0A3A5DDD2315D17F00473FDA"
@@ -125,8 +124,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7AE9D56F248EF6400029003C"
@@ -136,8 +134,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0A686491233E834D004B7E17"
@@ -147,8 +144,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D1B7EAEC257F02FC004F384A"
@@ -158,8 +154,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D147E62725CE242C001CFB5D"
@@ -176,16 +171,6 @@
                BuildableName = "AzureCommunicationCommonTests.xctest"
                BlueprintName = "AzureCommunicationCommonTests"
                ReferencedContainer = "container:sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AzureTemplate::AzureTemplateTests"
-               BuildableName = "AzureTemplateTests.xctest"
-               BlueprintName = "AzureTemplateTests"
-               ReferencedContainer = "container:sdk/template/AzureTemplate/AzureTemplate.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>

--- a/AzureSDK.xcworkspace/xcshareddata/xcschemes/sdk.xcscheme
+++ b/AzureSDK.xcworkspace/xcshareddata/xcschemes/sdk.xcscheme
@@ -152,6 +152,11 @@
                BlueprintName = "AzureCommunicationChatTests"
                ReferencedContainer = "container:sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "RecordableXCTestCase">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">
@@ -162,6 +167,11 @@
                BlueprintName = "AzureCommunicationChatUnitTests"
                ReferencedContainer = "container:sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "RecordableXCTestCase">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -179,7 +179,6 @@ jobs:
       - script: |
           xcrun simctl delete unavailable
           set -o pipefail
-          echo ${{parameters.BuildScheme}}
           xcodebuild -workspace AzureSDK.xcworkspace \
                      -scheme ${{parameters.BuildScheme}} \
                      -destination "platform=iOS Simulator,OS=$(SimulatorVersion),name=$(SimulatorDevice)" \

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -179,6 +179,7 @@ jobs:
       - script: |
           xcrun simctl delete unavailable
           set -o pipefail
+          echo ${{parameters.BuildScheme}}
           xcodebuild -workspace AzureSDK.xcworkspace \
                      -scheme ${{parameters.BuildScheme}} \
                      -destination "platform=iOS Simulator,OS=$(SimulatorVersion),name=$(SimulatorDevice)" \

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -185,7 +185,8 @@ jobs:
                      -configuration Debug \
                      -derivedDataPath $(Build.ArtifactStagingDirectory) \
                      -enableCodeCoverage YES \
-                     test | xcpretty -c
+                     -quiet \
+                     test
         displayName: 'Build and test libraries'
 
       - publish: $(Build.ArtifactStagingDirectory)/Logs/Test

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,6 @@
 variables:
   OSVmImage: 'macOS-10.15'
   DocWardenVersion: '0.5.0'
-  XcodeVersion: '12.3'
+  XcodeVersion: '12.5'
   SimulatorVersion: '14.3'
   SimulatorDevice: 'iPhone 12 Pro Max'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  OSVmImage: 'macOS-10.15'
+  OSVmImage: 'macOS-11.3'
   DocWardenVersion: '0.5.0'
   XcodeVersion: '12.5'
   SimulatorVersion: '14.3'

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/xcshareddata/xcschemes/AzureCommunicationChat.xcscheme
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/xcshareddata/xcschemes/AzureCommunicationChat.xcscheme
@@ -59,6 +59,11 @@
                BlueprintName = "AzureCommunicationChatTests"
                ReferencedContainer = "container:AzureCommunicationChat.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "RecordableXCTestCase">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">
@@ -69,6 +74,11 @@
                BlueprintName = "AzureCommunicationChatUnitTests"
                ReferencedContainer = "container:AzureCommunicationChat.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "RecordableXCTestCase">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
@@ -31,7 +31,7 @@ import AzureTest
 import DVR
 import XCTest
 
-class ChatClientDVRTests: XCRecordableTestCase<TestSettings> {
+class ChatClientDVRTests: RecordableXCTestCase<TestSettings> {
     /// ChatClient initialized in setup.
     private var chatClient: ChatClient!
 

--- a/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/ChatClientDVRTests.swift
@@ -31,7 +31,7 @@ import AzureTest
 import DVR
 import XCTest
 
-class ChatClientDVRTests: RecordableXCTestCase<TestSettings> {
+class ChatClientDVRTests: XCRecordableTestCase<TestSettings> {
     /// ChatClient initialized in setup.
     private var chatClient: ChatClient!
 


### PR DESCRIPTION
Updates dependencies so that CI will use macOS 11.3+ and XCode 12.5+. Unfortunately this will fail until we have build agents that can support. 

Fixes #974.