### PR TITLE
Change UserAgentPolicy to throw on validation errors and fix format

### DIFF
--- a/jazzy/AzureCore.yml
+++ b/jazzy/AzureCore.yml
@@ -2,7 +2,7 @@ author: Microsoft
 author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure/azure-sdk-for-ios
 module: AzureCore
-module_version: 1.0.0-beta.12
+module_version: 1.0.0-beta.13
 readme: ../sdk/core/AzureCore/README.md
 skip_undocumented: false
 hide_unlisted_documentation: false

--- a/sdk/core/AzureCore/AzureCore.podspec.json
+++ b/sdk/core/AzureCore/AzureCore.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCore",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "summary": "Azure core client library for iOS",
   "description": "This is the core framework for the Azure SDK for iOS, containing the HTTP\npipeline, as well as a shared set of components that are used across all\nclient libraries, including pipeline policies, error types, type aliases,\nan XML Codable implementation, and a logging system. As an end user, you\ndon't need to manually install AzureCore because it will be installed\nautomatically when you install other SDK libraries. If you are a client\nlibrary developer, please reference the AzureCommunicationChat library as\nan example of how to use the shared AzureCore components in your client\nlibrary.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureCore_1.0.0-beta.12"
+    "tag": "1.0.0-beta.13"
   },
   "source_files": "sdk/core/AzureCore/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/core/AzureCore/AzureCore.xcodeproj/project.pbxproj
+++ b/sdk/core/AzureCore/AzureCore.xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-beta.12";
+				MARKETING_VERSION = "1.0.0-beta.13";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.core.AzureCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -915,7 +915,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-beta.12";
+				MARKETING_VERSION = "1.0.0-beta.13";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.core.AzureCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/sdk/core/AzureCore/CHANGELOG.md
+++ b/sdk/core/AzureCore/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
+
+## 1.0.0-beta.13 (Unreleased)
+### Breaking Changes
+- `UserAgentPolicy` creation will now throw an error if a supplied application ID contains spaces or is longer than 24 characters. 
+  Previously, spaces would be removed and the application ID would be truncated.
+
 ## 1.0.0-beta.12 (2021-04-22)
 Minor update for Swift Package Manager.
-
 
 ## 1.0.0-beta.11 (2021-04-07)
 ### New Features

--- a/sdk/core/AzureCore/README.md
+++ b/sdk/core/AzureCore/README.md
@@ -57,7 +57,7 @@ specifying the clone URL of this repository and the version specifier you wish t
 // swift-tools-version:5.3
     dependencies: [
         ...
-        .package(name: "AzureCore", url: "https://github.com/Azure/SwiftPM-AzureCore.git", from: "1.0.0-beta.12")
+        .package(name: "AzureCore", url: "https://github.com/Azure/SwiftPM-AzureCore.git", from: "1.0.0-beta.13")
     ],
 ```
 
@@ -95,7 +95,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'MyTarget' do
-  pod 'AzureCore', '1.0.0-beta.12'
+  pod 'AzureCore', '1.0.0-beta.13'
   ...
 end
 ```

--- a/sdk/core/AzureCore/Tests/CollectionsTests.swift
+++ b/sdk/core/AzureCore/Tests/CollectionsTests.swift
@@ -60,7 +60,7 @@ class CollectionsTests: XCTestCase {
             endpoint: URL(string: "http://www.microsoft.com")!,
             transport: URLSessionTransport(),
             policies: [
-                UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
+                try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
             ],
             logger: ClientLoggers.default(),
             options: TestClientOptions()
@@ -98,7 +98,7 @@ class CollectionsTests: XCTestCase {
             endpoint: URL(string: "http://www.microsoft.com")!,
             transport: URLSessionTransport(),
             policies: [
-                UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
+                try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
             ],
             logger: ClientLoggers.default(),
             options: TestClientOptions()
@@ -126,7 +126,7 @@ class CollectionsTests: XCTestCase {
             endpoint: URL(string: "http://www.microsoft.com")!,
             transport: URLSessionTransport(),
             policies: [
-                UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
+                try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
             ],
             logger: ClientLoggers.default(),
             options: TestClientOptions()

--- a/sdk/core/AzureCore/Tests/PipelineTests.swift
+++ b/sdk/core/AzureCore/Tests/PipelineTests.swift
@@ -114,7 +114,7 @@ class PipelineTests: XCTestCase {
         var requestCompleted = false
 
         let client = TestClient(customPolicies: [
-            UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0"),
+            try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0"),
             RetryPolicy(),
             LoggingPolicy()
         ])
@@ -141,7 +141,7 @@ class PipelineTests: XCTestCase {
             perRetryPolicies: [CustomPerRetryPolicy()]
         )
         let client = TestClient(customPolicies: [
-            UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0"),
+            try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0"),
             RetryPolicy(),
             LoggingPolicy()
         ], withOptions: options)

--- a/sdk/core/AzureCore/Tests/Stubs/TestClient.swift
+++ b/sdk/core/AzureCore/Tests/Stubs/TestClient.swift
@@ -34,7 +34,7 @@ class TestClient: PipelineClient {
     public let options: TestClientOptions
 
     internal static let defaultPolicies: [PipelineStage] = [
-        UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0", telemetryOptions: TelemetryOptions()),
+        try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0", telemetryOptions: TelemetryOptions()),
         RetryPolicy(),
         LoggingPolicy()
     ]

--- a/sdk/core/AzureCore/Tests/XMLModelTests.swift
+++ b/sdk/core/AzureCore/Tests/XMLModelTests.swift
@@ -274,7 +274,7 @@ class XMLModelTests: XCTestCase {
             endpoint: URL(string: "http://www.microsoft.com")!,
             transport: URLSessionTransport(),
             policies: [
-                UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
+                try! UserAgentPolicy(sdkName: "Test", sdkVersion: "1.0")
             ],
             logger: ClientLoggers.default(),
             options: TestClientOptions()

--- a/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
+++ b/sdk/storage/AzureStorageBlob/Source/StorageBlobClient.swift
@@ -99,7 +99,7 @@ public final class StorageBlobClient: PipelineClient {
             endpoint: endpoint,
             transport: options.transportOptions.transport ?? URLSessionTransport(),
             policies: [
-                UserAgentPolicy(for: StorageBlobClient.self, telemetryOptions: options.telemetryOptions),
+                try UserAgentPolicy(for: StorageBlobClient.self, telemetryOptions: options.telemetryOptions),
                 RequestIdPolicy(),
                 AddDatePolicy(),
                 authPolicy,


### PR DESCRIPTION
Removes square brackets from application ID and now throws if application ID contains spaces or is longer than 24 characters. 