### PR TITLE
Point to AzureCore 1.0.0-beta.13

### DIFF
--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "AzureCore": [
-      "1.0.0-beta.12"
+      "1.0.0-beta.13"
     ],
     "AzureCommunicationCommon": [
       "~> 1.0"

--- a/sdk/communication/AzureCommunicationChat/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationChat/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix readOn property in readReceiptReceived events
 - Fix recipient id format in events
 - Upgrade Trouter package to 0.1.0
+- Update AzureCore package to 1.0.0-beta.13 to fix square brackets around applicationId
 
 ## 1.0.1 (2021-07-26)
 ### New Features

--- a/sdk/communication/AzureCommunicationChat/Package.swift
+++ b/sdk/communication/AzureCommunicationChat/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .library(name: "AzureCommunicationChat", targets: ["AzureCommunicationChat"])
     ],
     dependencies: [
-        .package(name: "AzureCore", url: "https://github.com/Azure/SwiftPM-AzureCore.git", from: "1.0.0-beta.12"),
+        .package(name: "AzureCore", url: "https://github.com/Azure/SwiftPM-AzureCore.git", from: "1.0.0-beta.13"),
         .package(
             name: "AzureCommunicationCommon",
             url: "https://github.com/Azure/SwiftPM-AzureCommunicationCommon.git",


### PR DESCRIPTION
Update AzureCore that includes fix for square brackets around applicationId