### PR TITLE
Update GA patch for preview6

### DIFF
--- a/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.xcodeproj/project.pbxproj
+++ b/examples/AzureSDKDemoSwift/AzureSDKDemoSwift.xcodeproj/project.pbxproj
@@ -62,9 +62,9 @@
 		0ABFEE4E26C2ECA200AB2B39 /* AzureIdentity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureIdentity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0ABFEE5126C2ECA800AB2B39 /* AzureStorageBlob.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureStorageBlob.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AF03F1B2433EE80002E65F8 /* CustomTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabBarController.swift; sourceTree = "<group>"; };
-		1C261B405813394338B82960 /* Pods-AzureSDKDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureSDKDemoSwift.release.xcconfig"; path = "../AzureSDKDemoSwift/Pods/Target Support Files/Pods-AzureSDKDemoSwift/Pods-AzureSDKDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
+		1C261B405813394338B82960 /* Pods-AzureSDKDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureSDKDemoSwift.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-AzureSDKDemoSwift/Pods-AzureSDKDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
 		9F31A5A26BA837DAEC8BD8E4 /* Pods_AzureSDKDemoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AzureSDKDemoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B0A776A40094923B6F31057B /* Pods-AzureSDKDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureSDKDemoSwift.debug.xcconfig"; path = "../AzureSDKDemoSwift/Pods/Target Support Files/Pods-AzureSDKDemoSwift/Pods-AzureSDKDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		B0A776A40094923B6F31057B /* Pods-AzureSDKDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureSDKDemoSwift.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-AzureSDKDemoSwift/Pods-AzureSDKDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		D10C3BCE25A63F7800A181E3 /* listParticipants.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BCD25A63F7800A181E3 /* listParticipants.json */; };
 		D10C3BD425A660AF00A181E3 /* listMessages.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BD325A660AF00A181E3 /* listMessages.json */; };
 		D10C3BDA25A66D4D00A181E3 /* listThreads.json in Resources */ = {isa = PBXBuildFile; fileRef = D10C3BD925A66D4D00A181E3 /* listThreads.json */; };
+		D10F55FB26E186F200742727 /* TestSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE5BA06267D25AD006B93B7 /* TestSettings.swift */; };
+		D10F55FE26E1874700742727 /* TrouterEventUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10F55FC26E1873600742727 /* TrouterEventUtilTests.swift */; };
 		D110F50A258D604B001FA3CD /* AzureCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D110F509258D604B001FA3CD /* AzureCore.framework */; };
 		D13CE65125BFB6D700415467 /* listReadReceipts.json in Resources */ = {isa = PBXBuildFile; fileRef = D13CE64E25BFB69100415467 /* listReadReceipts.json */; };
 		D147E62D25CE242C001CFB5D /* AzureCommunicationChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "AzureCommunicationChat::AzureCommunicationChat::Product" /* AzureCommunicationChat.framework */; };
@@ -239,6 +241,7 @@
 		D10C3BCD25A63F7800A181E3 /* listParticipants.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listParticipants.json; sourceTree = "<group>"; };
 		D10C3BD325A660AF00A181E3 /* listMessages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listMessages.json; sourceTree = "<group>"; };
 		D10C3BD925A66D4D00A181E3 /* listThreads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listThreads.json; sourceTree = "<group>"; };
+		D10F55FC26E1873600742727 /* TrouterEventUtilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrouterEventUtilTests.swift; sourceTree = "<group>"; };
 		D110F509258D604B001FA3CD /* AzureCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AzureCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D13CE64E25BFB69100415467 /* listReadReceipts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = listReadReceipts.json; sourceTree = "<group>"; };
 		D147E62825CE242C001CFB5D /* AzureCommunicationChatUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AzureCommunicationChatUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -519,6 +522,7 @@
 				D1CD93AB258D6C0300409613 /* Util */,
 				D1B7EAFC257F03A1004F384A /* Info.plist */,
 				0AE5BA06267D25AD006B93B7 /* TestSettings.swift */,
+				D10F55FC26E1873600742727 /* TrouterEventUtilTests.swift */,
 				8840448725D5DD7900A194DC /* IdentifierSerializerTests.swift */,
 				0ECA8CD1258181A5006760F7 /* ChatClientUnitTests.swift */,
 				0ECA8D08258432DC006760F7 /* ChatThreadClientUnitTests.swift */,
@@ -879,6 +883,8 @@
 				D147E64025CE244F001CFB5D /* ChatThreadClientUnitTests.swift in Sources */,
 				D1AEA09C2608EE3700849D5C /* Util.swift in Sources */,
 				D187D9B126151DB900C233B7 /* IdentifierSerializerTests.swift in Sources */,
+				D10F55FB26E186F200742727 /* TestSettings.swift in Sources */,
+				D10F55FE26E1874700742727 /* TrouterEventUtilTests.swift in Sources */,
 				D147E63925CE244A001CFB5D /* ChatClientUnitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/ChatClient.swift
@@ -249,6 +249,7 @@ public class ChatClient {
                         // Unable to refresh the token, stop the connection
                         if stopSignalingClient {
                             self.signalingClient?.stop()
+                            self.signalingClientStarted = false
                             self.options
                                 .signalingErrorHandler?(
                                     .failedToRefreshToken(

--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/Events/ChatEvent.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/Events/ChatEvent.swift
@@ -447,11 +447,7 @@ public class TypingIndicatorReceivedEvent: BaseChatEvent {
 
         self.version = typingIndicatorReceivedPayload.version
         self.receivedOn = Iso8601Date(string: typingIndicatorReceivedPayload.originalArrivalTime)
-        
-        if !typingIndicatorReceivedPayload.senderDisplayName.isEmpty {
-            self.senderDisplayName = typingIndicatorReceivedPayload.senderDisplayName
-        }
-
+        self.senderDisplayName = typingIndicatorReceivedPayload.senderDisplayName
         super.init(
             threadId: typingIndicatorReceivedPayload.groupId,
             sender: TrouterEventUtil.getIdentifier(from: typingIndicatorReceivedPayload.senderId),

--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/Events/ChatEvent.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/Events/ChatEvent.swift
@@ -321,7 +321,7 @@ public class ChatMessageEditedEvent: BaseChatMessageEvent {
         super.init(
             threadId: chatMessageEditedPayload.groupId,
             sender: TrouterEventUtil.getIdentifier(from: chatMessageEditedPayload.senderId),
-            recipient: TrouterEventUtil.getIdentifier(from: chatMessageEditedPayload.recipientId),
+            recipient: TrouterEventUtil.getIdentifier(from: chatMessageEditedPayload.recipientMri),
             id: chatMessageEditedPayload.messageId,
             senderDisplayName: chatMessageEditedPayload.senderDisplayName,
             createdOn: Iso8601Date(string: chatMessageEditedPayload.originalArrivalTime),
@@ -389,7 +389,7 @@ public class ChatMessageDeletedEvent: BaseChatMessageEvent {
         super.init(
             threadId: chatMessageDeletedPayload.groupId,
             sender: TrouterEventUtil.getIdentifier(from: chatMessageDeletedPayload.senderId),
-            recipient: TrouterEventUtil.getIdentifier(from: chatMessageDeletedPayload.recipientId),
+            recipient: TrouterEventUtil.getIdentifier(from: chatMessageDeletedPayload.recipientMri),
             id: chatMessageDeletedPayload.messageId,
             senderDisplayName: chatMessageDeletedPayload.senderDisplayName,
             createdOn: Iso8601Date(string: chatMessageDeletedPayload.originalArrivalTime),
@@ -451,7 +451,7 @@ public class TypingIndicatorReceivedEvent: BaseChatEvent {
         super.init(
             threadId: typingIndicatorReceivedPayload.groupId,
             sender: TrouterEventUtil.getIdentifier(from: typingIndicatorReceivedPayload.senderId),
-            recipient: TrouterEventUtil.getIdentifier(from: typingIndicatorReceivedPayload.recipientId)
+            recipient: TrouterEventUtil.getIdentifier(from: typingIndicatorReceivedPayload.recipientMri)
         )
     }
 }
@@ -518,7 +518,7 @@ public class ReadReceiptReceivedEvent: BaseChatEvent {
         super.init(
             threadId: readReceiptReceivedPayload.groupId,
             sender: TrouterEventUtil.getIdentifier(from: readReceiptReceivedPayload.senderId),
-            recipient: TrouterEventUtil.getIdentifier(from: readReceiptReceivedPayload.recipientId)
+            recipient: TrouterEventUtil.getIdentifier(from: readReceiptReceivedPayload.recipientMri)
         )
     }
 }

--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterNotificationPayload.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterNotificationPayload.swift
@@ -29,14 +29,13 @@ import Foundation
 struct BasePayload: Codable {
     let eventId: Int
     let senderId: String
-    let recipientId: String
+    let recipientMri: String
     let groupId: String
 }
 
 struct MessageReceivedPayload: Decodable {
     let eventId: Int
     let senderId: String
-    let recipientId: String
     let recipientMri: String
     let transactionId: String
     let groupId: String
@@ -54,7 +53,7 @@ struct MessageReceivedPayload: Decodable {
 struct TypingIndicatorReceivedPayload: Decodable {
     let eventId: Int
     let senderId: String
-    let recipientId: String
+    let recipientMri: String
     let groupId: String
     let version: String
     let originalArrivalTime: String
@@ -71,7 +70,7 @@ struct ReadReceiptMessageBody: Decodable {
 struct ReadReceiptReceivedPayload: Decodable {
     let eventId: Int
     let senderId: String
-    let recipientId: String
+    let recipientMri: String
     let groupId: String
     let messageId: String
     let clientMessageId: String
@@ -81,7 +80,7 @@ struct ReadReceiptReceivedPayload: Decodable {
 struct MessageEditedPayload: Decodable {
     let eventId: Int
     let senderId: String
-    let recipientId: String
+    let recipientMri: String
     let groupId: String
     let messageId: String
     let clientMessageId: String
@@ -97,7 +96,7 @@ struct MessageEditedPayload: Decodable {
 struct MessageDeletedPayload: Decodable {
     let eventId: Int
     let senderId: String
-    let recipientId: String
+    let recipientMri: String
     let groupId: String
     let messageId: String
     let clientMessageId: String

--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterNotificationPayload.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterNotificationPayload.swift
@@ -29,7 +29,7 @@ import Foundation
 struct BasePayload: Codable {
     let eventId: Int
     let senderId: String
-    let recipientMri: String
+    let recipientId: String
     let groupId: String
 }
 

--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterNotificationPayload.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterNotificationPayload.swift
@@ -27,18 +27,14 @@
 import Foundation
 
 struct BasePayload: Codable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let senderId: String
     let recipientId: String
     let groupId: String
 }
 
 struct MessageReceivedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let senderId: String
     let recipientId: String
     let recipientMri: String
@@ -56,14 +52,13 @@ struct MessageReceivedPayload: Decodable {
 }
 
 struct TypingIndicatorReceivedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let senderId: String
     let recipientId: String
     let groupId: String
     let version: String
     let originalArrivalTime: String
+    let senderDisplayName: String
 }
 
 struct ReadReceiptMessageBody: Decodable {
@@ -74,9 +69,7 @@ struct ReadReceiptMessageBody: Decodable {
 }
 
 struct ReadReceiptReceivedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let senderId: String
     let recipientId: String
     let groupId: String
@@ -86,9 +79,7 @@ struct ReadReceiptReceivedPayload: Decodable {
 }
 
 struct MessageEditedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let senderId: String
     let recipientId: String
     let groupId: String
@@ -104,9 +95,7 @@ struct MessageEditedPayload: Decodable {
 }
 
 struct MessageDeletedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let senderId: String
     let recipientId: String
     let groupId: String
@@ -120,9 +109,7 @@ struct MessageDeletedPayload: Decodable {
 }
 
 struct ChatThreadPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let threadId: String
     let version: String
 }
@@ -134,9 +121,7 @@ struct ChatParticipantPayload: Decodable {
 }
 
 struct ChatThreadCreatedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let threadId: String
     let version: String
     let createTime: String
@@ -150,9 +135,7 @@ struct ChatThreadPropertiesPayload: Decodable {
 }
 
 struct ChatThreadPropertiesUpdatedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let threadId: String
     let version: String
     let editTime: String
@@ -161,9 +144,7 @@ struct ChatThreadPropertiesUpdatedPayload: Decodable {
 }
 
 struct ChatThreadDeletedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let threadId: String
     let version: String
     let deleteTime: String
@@ -171,9 +152,7 @@ struct ChatThreadDeletedPayload: Decodable {
 }
 
 struct ParticipantsAddedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let threadId: String
     let version: String
     let time: String
@@ -182,9 +161,7 @@ struct ParticipantsAddedPayload: Decodable {
 }
 
 struct ParticipantsRemovedPayload: Decodable {
-    // swiftlint:disable identifier_name
     let eventId: Int
-    // swiftlint:enable identifier_name
     let threadId: String
     let version: String
     let time: String

--- a/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
@@ -69,26 +69,7 @@ class TrouterEventUtilTests: XCTestCase {
 
     func test_createChatMessageReceivedEvent_withSenderDisplayName() {
         do {
-            let payload = """
-                {
-                    "eventId": 200,
-                    "senderId": "\(senderId)",
-                    "recipientId": "\(payloadRecipientId)",
-                    "recipientMri": "\(payloadRecipientMri)",
-                    "transactionId": "transactionId",
-                    "groupId": "\(threadId)",
-                    "messageId": "\(messageId)",
-                    "collapseId": "collapseId",
-                    "messageType": "\(ChatMessageType.text.requestString)",
-                    "messageBody": "\(messageContent)",
-                    "senderDisplayName": "\(senderDisplayName)",
-                    "clientMessageId": "",
-                    "originalArrivalTime": "\(dateString)",
-                    "priority": "",
-                    "version": "\(version)",
-                    "acsChatMessageMetadata:" : "null"
-                }
-            """
+            let payload = "{\"eventId\": 200,\"senderId\": \"\(senderId)\",\"recipientId\": \"\(payloadRecipientId)\",\"recipientMri\": \"\(payloadRecipientMri)\",\"transactionId\": \"transactionId\",\"groupId\": \"\(threadId)\",\"messageId\": \"\(messageId)\",\"collapseId\":\"collapseId\",\"messageType\": \"\(ChatMessageType.text.requestString)\",\"messageBody\": \"\(messageContent)\",\"senderDisplayName\": \"\(senderDisplayName)\",\"clientMessageId\": \"\",\"originalArrivalTime\": \"\(dateString)\",\"priority\": \"\",\"version\": \"\(version)\",\"acsChatMessageMetadata\": \"null\"}"
 
             let trouterRequest = TrouterRequestMock(
                 id: 1,
@@ -127,26 +108,7 @@ class TrouterEventUtilTests: XCTestCase {
 
     func test_createChatMessageReceivedEvent_withoutDisplayNameOrMetdata() {
         do {
-            let payload = """
-                {
-                    "eventId": 200,
-                    "senderId": "\(senderId)",
-                    "recipientId": "\(payloadRecipientId)",
-                    "recipientMri": "\(payloadRecipientMri)",
-                    "transactionId": "transactionId",
-                    "groupId": "\(threadId)",
-                    "messageId": "\(messageId)",
-                    "collapseId": "collapseId",
-                    "messageType": "\(ChatMessageType.text.requestString)",
-                    "messageBody": "\(messageContent)",
-                    "senderDisplayName": "\(emptyDisplayName)",
-                    "clientMessageId": "",
-                    "originalArrivalTime": "\(dateString)",
-                    "priority": "",
-                    "version": "\(version)",
-                    "acsChatMessageMetadata:" : "null"
-                }
-            """
+            let payload = "{\"eventId\": 200,\"senderId\": \"\(senderId)\",\"recipientId\": \"\(payloadRecipientId)\",\"recipientMri\": \"\(payloadRecipientMri)\",\"transactionId\": \"transactionId\",\"groupId\": \"\(threadId)\",\"messageId\": \"\(messageId)\",\"collapseId\":\"collapseId\",\"messageType\": \"\(ChatMessageType.text.requestString)\",\"messageBody\": \"\(messageContent)\",\"senderDisplayName\": \"\(emptyDisplayName)\",\"clientMessageId\": \"\",\"originalArrivalTime\": \"\(dateString)\",\"priority\": \"\",\"version\": \"\(version)\",\"acsChatMessageMetadata\": \"null\"}"
 
             let trouterRequest = TrouterRequestMock(
                 id: 1,
@@ -292,28 +254,7 @@ class TrouterEventUtilTests: XCTestCase {
     func test_createChatMessageEditedEvent_withoutSenderDisplayNameOrMetadata() {
         do {
             let editTime = "2021-08-26T20:33:17.651Z"
-            let payload = """
-                {
-                    "eventId": 247,
-                    "senderId": "\(senderId)",
-                    "recipientId": "\(payloadRecipientId)",
-                    "recipientMri": "\(payloadRecipientMri)",
-                    "transactionId": "transactionId",
-                    "groupId": "\(threadId)",
-                    "messageId": "\(messageId)",
-                    "collapseId": "collapseId",
-                    "messageType": "\(ChatMessageType.text.requestString)",
-                    "messageBody": "\(messageContent)",
-                    "senderDisplayName": "\(emptyDisplayName)",
-                    "clientMessageId": "",
-                    "originalArrivalTime": "\(dateString)",
-                    "priority": "",
-                    "version": "\(version)",
-                    "edittime": "\(editTime)",
-                    "composetime": "2021-08-26T20:30:09.593Z"
-                    "acsChatMessageMetadata": "{}"
-                }
-            """
+            let payload = "{\"eventId\": 247,\"senderId\": \"\(senderId)\",\"recipientId\": \"\(payloadRecipientId)\",\"recipientMri\": \"\(payloadRecipientMri)\",\"transactionId\": \"transactionId\",\"groupId\": \"\(threadId)\",\"messageId\": \"\(messageId)\",\"collapseId\":\"collapseId\",\"messageType\": \"\(ChatMessageType.text.requestString)\",\"messageBody\": \"\(messageContent)\",\"senderDisplayName\": \"\(emptyDisplayName)\",\"clientMessageId\": \"\",\"originalArrivalTime\": \"\(dateString)\",\"priority\": \"\",\"version\": \"\(version)\",\"edittime\": \"\(editTime)\",\"composetime\": \"2021-09-03T17:35:28.663Z\",\"acsChatMessageMetadata\": \"{}\"}"
 
             let trouterRequest = TrouterRequestMock(
                 id: 1,

--- a/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
@@ -354,29 +354,10 @@ class TrouterEventUtilTests: XCTestCase {
 
     func test_createChatMessageEditedEvent_withMetadata() {
         do {
+            let metadataKey = "testKey"
+            let metadataValue = "testValue"
             let editTime = "2021-08-26T20:33:17.651Z"
-            let payload = """
-                {
-                    "eventId": 247,
-                    "senderId": "\(senderId)",
-                    "recipientId": "\(payloadRecipientId)",
-                    "recipientMri": "\(payloadRecipientMri)",
-                    "transactionId": "transactionId",
-                    "groupId": "\(threadId)",
-                    "messageId": "\(messageId)",
-                    "collapseId": "collapseId",
-                    "messageType": "\(ChatMessageType.text.requestString)",
-                    "messageBody": "\(messageContent)",
-                    "senderDisplayName": "\(senderDisplayName)",
-                    "clientMessageId": "",
-                    "originalArrivalTime": "\(dateString)",
-                    "priority": "",
-                    "version": "\(version)",
-                    "edittime": "\(editTime)",
-                    "composetime": "2021-08-26T20:30:09.593Z",
-                    "acsChatMessageMetadata": "{}"
-                }
-            """
+            let payload = "{\"eventId\": 247,\"senderId\": \"\(senderId)\",\"recipientId\": \"\(payloadRecipientId)\",\"recipientMri\": \"\(payloadRecipientMri)\",\"transactionId\": \"transactionId\",\"groupId\": \"\(threadId)\",\"messageId\": \"\(messageId)\",\"collapseId\":\"collapseId\",\"messageType\": \"\(ChatMessageType.text.requestString)\",\"messageBody\": \"\(messageContent)\",\"senderDisplayName\": \"\(emptyDisplayName)\",\"clientMessageId\": \"\",\"originalArrivalTime\": \"\(dateString)\",\"priority\": \"\",\"version\": \"\(version)\",\"edittime\": \"\(editTime)\",\"composetime\": \"2021-09-03T17:18:05.114Z\",\"acsChatMessageMetadata\": \"{\\\"\(metadataKey)\\\":\\\"\(metadataValue)\\\"}\"}"
 
             let trouterRequest = TrouterRequestMock(
                 id: 1,
@@ -395,7 +376,7 @@ class TrouterEventUtilTests: XCTestCase {
                 XCTAssertEqual(event.id, messageId)
                 XCTAssertEqual(event.createdOn, Iso8601Date(string: dateString))
                 XCTAssertEqual(event.message, messageContent)
-                XCTAssertEqual(event.senderDisplayName, senderDisplayName)
+                XCTAssertEqual(event.senderDisplayName, emptyDisplayName)
                 XCTAssertEqual(event.threadId, threadId)
                 XCTAssertEqual(event.type, .text)
                 XCTAssertEqual(event.version, version)

--- a/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
@@ -56,7 +56,7 @@ class TrouterRequestMock: NSObject, TrouterRequest {
 
 class TrouterEventUtilTests: XCTestCase {
     let senderId = "8:acs:senderId"
-    let payloadRecipientId = "acs:recipientId"
+    let payloadRecipientId = "8:acs:recipientId"
     let expectedRecipientId = "8:acs:recipientId"
     let messageId = "123"
     let threadId = "thread123"
@@ -70,7 +70,7 @@ class TrouterEventUtilTests: XCTestCase {
         do {
             let payload = """
                 {
-                    "_eventId": 200,
+                    "eventId": 200,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -126,7 +126,7 @@ class TrouterEventUtilTests: XCTestCase {
         do {
             let payload = """
                 {
-                    "_eventId": 200,
+                    "eventId": 200,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -183,7 +183,7 @@ class TrouterEventUtilTests: XCTestCase {
             let editTime = "2021-08-26T20:33:17.651Z"
             let payload = """
                 {
-                    "_eventId": 247,
+                    "eventId": 247,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -243,7 +243,7 @@ class TrouterEventUtilTests: XCTestCase {
             let editTime = "2021-08-26T20:33:17.651Z"
             let payload = """
                 {
-                    "_eventId": 247,
+                    "eventId": 247,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -303,7 +303,7 @@ class TrouterEventUtilTests: XCTestCase {
             let deleteTime = "2021-08-26T20:34:21.322Z"
             let payload = """
                 {
-                    "_eventId": 248,
+                    "eventId": 248,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -360,7 +360,7 @@ class TrouterEventUtilTests: XCTestCase {
             let deleteTime = "2021-08-26T20:34:21.322Z"
             let payload = """
                 {
-                    "_eventId": 248,
+                    "eventId": 248,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -416,7 +416,7 @@ class TrouterEventUtilTests: XCTestCase {
         do {
             let payload = """
                 {
-                    "_eventId": 245,
+                    "eventId": 245,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -475,7 +475,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 246,
+                    "eventId": 246,
                     "senderId": "\(senderId)",
                     "recipientId": "\(payloadRecipientId)",
                     "transactionId": "transactionId",
@@ -539,7 +539,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 257,
+                    "eventId": 257,
                     "senderId": "\(senderId)",
                     "createdBy": \(createdBy),
                     "recipientId": "\(userId)",
@@ -612,7 +612,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 257,
+                    "eventId": 257,
                     "senderId": "\(senderId)",
                     "createdBy": \(createdBy),
                     "recipientId": "\(userId)",
@@ -680,7 +680,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 258,
+                    "eventId": 258,
                     "senderId": "\(senderId)",
                     "editedBy": \(editedBy),
                     "recipientId": "\(payloadRecipientId)",
@@ -737,7 +737,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 258,
+                    "eventId": 258,
                     "senderId": "\(senderId)",
                     "editedBy": \(editedBy),
                     "recipientId": "\(payloadRecipientId)",
@@ -792,7 +792,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 259,
+                    "eventId": 259,
                     "senderId": "\(senderId)",
                     "deletedBy": \(deletedBy),
                     "recipientId": "\(payloadRecipientId)",
@@ -843,7 +843,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 259,
+                    "eventId": 259,
                     "senderId": "\(senderId)",
                     "deletedBy": \(deletedBy),
                     "recipientId": "\(payloadRecipientId)",
@@ -898,7 +898,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 260,
+                    "eventId": 260,
                     "senderId": "\(senderId)",
                     "addedBy": \(addedBy),
                     "recipientId": "\(payloadRecipientId)",
@@ -956,7 +956,7 @@ class TrouterEventUtilTests: XCTestCase {
 
             let payload = """
                 {
-                    "_eventId": 260,
+                    "eventId": 260,
                     "senderId": "\(senderId)",
                     "addedBy": \(addedBy),
                     "recipientId": "\(payloadRecipientId)",

--- a/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/TrouterEventUtilTests.swift
@@ -187,26 +187,29 @@ class TrouterEventUtilTests: XCTestCase {
         do {
             let metadataKey = "testKey"
             let metadataValue = "testValue"
+//            let payload = """
+//                {
+//                    "eventId": 200,
+//                    "senderId": "\(senderId)",
+//                    "recipientId": "\(payloadRecipientId)",
+//                    "recipientMri": "\(payloadRecipientMri)",
+//                    "transactionId": "transactionId",
+//                    "groupId": "\(threadId)",
+//                    "messageId": "\(messageId)",
+//                    "collapseId": "collapseId",
+//                    "messageType": "\(ChatMessageType.text.requestString)",
+//                    "messageBody": "\(messageContent)",
+//                    "senderDisplayName": "\(senderDisplayName)",
+//                    "clientMessageId": "",
+//                    "originalArrivalTime": "\(dateString)",
+//                    "priority": "",
+//                    "version": "\(version)"
+//                    "acsChatMessageMetadata:" : "null"
+//                }
+//            """
             let payload = """
-                {
-                    "eventId": 200,
-                    "senderId": "\(senderId)",
-                    "recipientId": "\(payloadRecipientId)",
-                    "recipientMri": "\(payloadRecipientMri)",
-                    "transactionId": "transactionId",
-                    "groupId": "\(threadId)",
-                    "messageId": "\(messageId)",
-                    "collapseId": "collapseId",
-                    "messageType": "\(ChatMessageType.text.requestString)",
-                    "messageBody": "\(messageContent)",
-                    "senderDisplayName": "\(senderDisplayName)",
-                    "clientMessageId": "",
-                    "originalArrivalTime": "\(dateString)",
-                    "priority": "",
-                    "version": "\(version)"
-                    "acsChatMessageMetadata:" : "null"
-                }
-            """
+                {"eventId": 200,"senderId": "8:acs:4fba785c-8d9d-4e5b-8c60-2a02d49866e6_0000000c-48ad-754b-a4f5-343a0d000661","recipientId": "acs:4fba785c-8d9d-4e5b-8c60-2a02d49866e6_0000000c-48ad-754b-a4f5-343a0d000661","recipientMri": "8:acs:4fba785c-8d9d-4e5b-8c60-2a02d49866e6_0000000c-48ad-754b-a4f5-343a0d000661","transactionId": "iouSVS0P1kqIyXI6EcZ6Fg.1.2.1.1.2061405687.1.0","groupId": "19:gwBxt3whRNMG47wWP8L21bG79bW4TvVll7JFnZ0Xan81@thread.v2","messageId": "1630687799638","collapseId":"YKbqPoEf002p+jGu+AWJkv6SrnRoqHuRh5X6PAP9Sn4=","messageType": "Text","messageBody": "This is a message from Bob!","senderDisplayName": "","clientMessageId": "","originalArrivalTime": "2021-09-03T16:49:59.638Z","priority": "","version": "1630687799638","acsChatMessageMetadata": "{\"testkey\":\"testvalue\"}"}
+                """
 
             let trouterRequest = TrouterRequestMock(
                 id: 1,


### PR DESCRIPTION
- The version of notification payloads in preview6 uses recipientMri instead of recipientId
- Fix null metadata check to look for "null" instead of empty string
- Update payload unit tests