### PR TITLE
Prevent BoM upload failure on failed builds

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -56,6 +56,7 @@ jobs:
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate Package BOM'
+        condition: succeededOrFailed()
         inputs:
           BuildDropPath: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
This is the same condition fix (with the same logic) that is applied in this PR Azure/azure-sdk-for-cpp#3256