### PR TITLE
[AzureCore] Fix transport callback fallthrough

### DIFF
--- a/sdk/core/AzureCore/CHANGELOG.md
+++ b/sdk/core/AzureCore/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 1.0.0-beta.14 (Unreleased)
+## 1.0.0-beta.15 (Unreleased)
+### Bugs Fixed
+- Fixed issue where pipeline calls multiple callback if a bad status code was received.
+
+## 1.0.0-beta.14 (2022-02-10)
 
 ### Bugs Fixed
 - Fixed issue where certain system errors would be swallowed by AzureCore instead of passed

--- a/sdk/core/AzureCore/Source/Pipeline/Transport/URLSessionTransport.swift
+++ b/sdk/core/AzureCore/Source/Pipeline/Transport/URLSessionTransport.swift
@@ -118,6 +118,7 @@ public class URLSessionTransport: TransportStage {
                 // do not add the inner error, as it may require decoding from XML.
                 let error = AzureError.service("Service returned invalid status code [\(statusCode)]", nil)
                 completionHandler(.failure(error), httpResponse)
+                return
             }
 
             let pipelineResponse = PipelineResponse(

--- a/sdk/test/AzureTest/Source/DVRSessionTransport.swift
+++ b/sdk/test/AzureTest/Source/DVRSessionTransport.swift
@@ -93,7 +93,9 @@ public class DVRSessionTransport: TransportStage {
             "operation-location": .remove,
             "azure-asyncoperation": .remove,
             "www-authenticate": .remove,
-            "access_token": .remove
+            "access_token": .remove,
+            "Date": .remove,
+            "X-Skypetoken": .remove
         ]
 
         session = Session(outputDirectory: outputDirectory, cassetteName: cassetteName)
@@ -179,6 +181,7 @@ public class DVRSessionTransport: TransportStage {
                 // do not add the inner error, as it may require decoding from XML.
                 let error = AzureError.service("Service returned invalid status code [\(statusCode)].", nil)
                 completionHandler(.failure(error), httpResponse)
+                return
             }
 
             let pipelineResponse = PipelineResponse(


### PR DESCRIPTION
Fixes for AzureCore and AzureTest to prevent a callback fallthrough in the event of a bad status code. Also adds other fixes needed by Chat until more permanent measures can be implemented. 