### PR TITLE
[CommunicationIdentifier] Introduce new rawId and creation of identifer

### DIFF
--- a/sdk/communication/AzureCommunicationChat/Tests/IdentifierSerializerTests.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/IdentifierSerializerTests.swift
@@ -144,10 +144,6 @@ class IdentifierSerializerTests: XCTestCase {
         try serializePhoneNumber(expectedId: testRawId)
     }
 
-    func test_SerializePhoneNumber_ExpectedIdNil() throws {
-        try serializePhoneNumber(expectedId: nil)
-    }
-
     func serializePhoneNumber(expectedId: String?) throws {
         let model = try IdentifierSerializer
             .serialize(identifier: PhoneNumberIdentifier(phoneNumber: testPhoneNumber, rawId: expectedId))

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		882F28D425A632CA009689E3 /* CommunicationTokenRefreshOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882F28D325A632CA009689E3 /* CommunicationTokenRefreshOptions.swift */; };
 		8856CEAC253A376D00044559 /* CommunicationAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */; };
 		8856CEE5253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8856CEE4253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m */; };
+		8889890E28245398002C5C82 /* CommunicationIdentifierHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8889890D28245398002C5C82 /* CommunicationIdentifierHelper.swift */; };
+		8889891028246763002C5C82 /* CommunicationIdentifierHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8889890F28246763002C5C82 /* CommunicationIdentifierHelperTests.swift */; };
 		88CC8C35254750260028977C /* ObjCCommunicationTokenCredentialAsyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88CC8C34254750260028977C /* ObjCCommunicationTokenCredentialAsyncTests.m */; };
 		88F1F570254A07BC00876BC4 /* ObjCTokenParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F1F56F254A07BC00876BC4 /* ObjCTokenParserTests.m */; };
 		C1ABE73016C6539A7175199B /* Pods_AzureCommunicationCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D532B0F56C67A1E89941A6D6 /* Pods_AzureCommunicationCommon.framework */; };
@@ -60,6 +62,8 @@
 		8856CEAB253A376D00044559 /* CommunicationAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationAccessToken.swift; sourceTree = "<group>"; };
 		8856CEE3253E3AEF00044559 /* AzureCommunicationCommonTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AzureCommunicationCommonTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		8856CEE4253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCCommunicationTokenCredentialTests.m; sourceTree = "<group>"; };
+		8889890D28245398002C5C82 /* CommunicationIdentifierHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationIdentifierHelper.swift; sourceTree = "<group>"; };
+		8889890F28246763002C5C82 /* CommunicationIdentifierHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationIdentifierHelperTests.swift; sourceTree = "<group>"; };
 		88CC8C34254750260028977C /* ObjCCommunicationTokenCredentialAsyncTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCCommunicationTokenCredentialAsyncTests.m; sourceTree = "<group>"; };
 		88F1F56F254A07BC00876BC4 /* ObjCTokenParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCTokenParserTests.m; sourceTree = "<group>"; };
 		CC958AD71D0F5F2AAAF8CD78 /* Pods-AzureCommunicationCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureCommunicationCommon.debug.xcconfig"; path = "Target Support Files/Pods-AzureCommunicationCommon/Pods-AzureCommunicationCommon.debug.xcconfig"; sourceTree = "<group>"; };
@@ -125,6 +129,7 @@
 				1D2E7F6E24E4536500447964 /* Authentication */,
 				1DC3550524D9F02D0095ABD9 /* Supporting Files */,
 				1D2E7F6F24E4589100447964 /* Identifiers.swift */,
+				8889890D28245398002C5C82 /* CommunicationIdentifierHelper.swift */,
 				F1540EBC25BF893C0056B087 /* CommunicationCloudEnvironment.swift */,
 			);
 			path = Source;
@@ -140,6 +145,7 @@
 				8856CEE3253E3AEF00044559 /* AzureCommunicationCommonTests-Bridging-Header.h */,
 				88F1F56F254A07BC00876BC4 /* ObjCTokenParserTests.m */,
 				F1540EC025BFD6910056B087 /* CommunicationIdentifierTest.swift */,
+				8889890F28246763002C5C82 /* CommunicationIdentifierHelperTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -362,6 +368,7 @@
 				F183A5EB24AF9D9000F0E0D5 /* CommunicationTokenCredentialProviding.swift in Sources */,
 				1D2E7F7024E4589100447964 /* Identifiers.swift in Sources */,
 				8856CEAC253A376D00044559 /* CommunicationAccessToken.swift in Sources */,
+				8889890E28245398002C5C82 /* CommunicationIdentifierHelper.swift in Sources */,
 				1DE4DB7924C1063E00631921 /* ThreadSafeRefreshableAccessTokenCache.swift in Sources */,
 				1DE4DB7724C0FE8300631921 /* AutoRefreshTokenCredential.swift in Sources */,
 				F1540EBD25BF893C0056B087 /* CommunicationCloudEnvironment.swift in Sources */,
@@ -380,6 +387,7 @@
 				88F1F570254A07BC00876BC4 /* ObjCTokenParserTests.m in Sources */,
 				8856CEE5253E3AEF00044559 /* ObjCCommunicationTokenCredentialTests.m in Sources */,
 				F1540EC125BFD6910056B087 /* CommunicationIdentifierTest.swift in Sources */,
+				8889891028246763002C5C82 /* CommunicationIdentifierHelperTests.swift in Sources */,
 				1D07222D24C8FB0F00C2EF4E /* CommunicationTokenCredentialTests.swift in Sources */,
 				88CC8C35254750260028977C /* ObjCCommunicationTokenCredentialAsyncTests.m in Sources */,
 			);

--- a/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Release History
 
-## 1.0.4 (upcoming)
+## 1.1.0 (upcoming)
 ### New Features
 - Introduce new `CommunicationIdentifierHelper` to create `CommunicationIdentifier` based on rawIds
 - Introduce new `rawId` getter property in the `CommunicationIdentifier` protocol 
+
+### Key Bug Fixes 
+- `PhoneNumberIdentifier` no longer allows the `rawId` to not correspond with the phone number
 
 ## 1.0.3 (2022-03-10)
 ### New Features

--- a/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.0.4 (upcoming)
+### New Features
+- Introduce new `CommunicationIdentifierHelper` to create `CommunicationIdentifier` based on rawIds
+- Introduce new `rawId` getter property in the `CommunicationIdentifier` protocol 
+
 ## 1.0.3 (2022-03-10)
 ### New Features
 - Update `AzureCore` dependency to beta 15.

--- a/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
+++ b/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
@@ -25,9 +25,17 @@
 // --------------------------------------------------------------------------
 
 import Foundation
-
+/**
+ Helper class to easily create CommunicationIdentifiers
+ */
 @objcMembers
 public class CommunicationIdentifierHelper: NSObject {
+    /**
+     Creates a CommunicationIdentifier from a given rawId. When storing rawIds use this function to restore the identifier that was encoded in the rawId.
+     Parameters: rawId The rawId to be translated to its identifier representation.
+     Returns: Type safe CommunicationIdentifier created. Use the `isKind(of:)` to verify  identifier type
+     SeeAlso: ` CommunicationIdentifier`
+     */
     public static func createCommunicationIdentifier(from rawId: String) -> CommunicationIdentifier {
         let phoneNumberPrefix = "4:"
         let teamUserAnonymousPrefix = "8:teamsvisitor:"

--- a/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
+++ b/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
@@ -30,6 +30,15 @@ import Foundation
  */
 @objcMembers
 public class CommunicationIdentifierHelper: NSObject {
+    private static let phoneNumberPrefix = "4:"
+    private static let teamUserAnonymousPrefix = "8:teamsvisitor:"
+    private static let teamUserPublicCloudPrefix = "8:orgid:"
+    private static let teamUserDODCloudPrefix = "8:dod:"
+    private static let teamUserGCCHCloudPrefix = "8:gcch:"
+    private static let acsUser = "8:acs:"
+    private static let spoolUser = "8:spool:"
+    private static let dodAcsUser = "8:dod-acs:"
+    private static let gcchAcsUser = "8:gcch-acs:"
     /**
      Creates a CommunicationIdentifier from a given rawId. When storing rawIds use this function to restore the identifier that was encoded in the rawId.
      Parameters: rawId The rawId to be translated to its identifier representation.
@@ -37,29 +46,16 @@ public class CommunicationIdentifierHelper: NSObject {
      SeeAlso: ` CommunicationIdentifier`
      */
     public static func createCommunicationIdentifier(from rawId: String) -> CommunicationIdentifier {
-        let phoneNumberPrefix = "4:"
-        let teamUserAnonymousPrefix = "8:teamsvisitor:"
-        let teamUserPublicCloudPrefix = "8:orgid:"
-        let teamUserDODCloudPrefix = "8:dod:"
-        let teamUserGCCHCloudPrefix = "8:gcch:"
-        let acsUser = "8:acs:"
-        let spoolUser = "8:spool:"
-        let dodAcsUser = "8:dod-acs:"
-        let gcchAcsUser = "8:gcch-acs:"
-
         if rawId.hasPrefix(phoneNumberPrefix) {
             let phoneNumber = "+" + rawId.dropFirst(phoneNumberPrefix.count)
             return PhoneNumberIdentifier(phoneNumber: phoneNumber, rawId: rawId)
         }
-
         let segments = rawId.split(separator: ":")
         if segments.count < 3 {
             return UnknownIdentifier(rawId)
         }
-
         let scope = segments[0] + ":" + segments[1] + ":"
         let suffix = String(rawId.dropFirst(scope.count))
-
         switch scope {
         case teamUserAnonymousPrefix:
             return MicrosoftTeamsUserIdentifier(userId: suffix, isAnonymous: true)

--- a/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
+++ b/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
@@ -1,0 +1,81 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+@objcMembers
+public class CommunicationIdentifierHelper: NSObject {
+    public static func createCommunicationIdentifier(from rawId: String) -> CommunicationIdentifier {
+        let phoneNumberPrefix = "4:"
+        let teamUserAnonymousPrefix = "8:teamsvisitor:"
+        let teamUserPublicCloudPrefix = "8:orgid:"
+        let teamUserDODCloudPrefix = "8:dod:"
+        let teamUserGCCHCloudPrefix = "8:gcch:"
+
+        if rawId.hasPrefix(phoneNumberPrefix) {
+            let phoneNumber = "+" + rawId.dropFirst(phoneNumberPrefix.count)
+            return PhoneNumberIdentifier(phoneNumber: phoneNumber, rawId: rawId)
+        }
+
+        let segments = rawId.split(separator: ":")
+        if segments.count < 3 {
+            return UnknownIdentifier(rawId)
+        }
+
+        let scope = segments[0] + ":" + segments[1] + ":"
+        let suffix = String(rawId.dropFirst(scope.count))
+
+        switch scope {
+        case teamUserAnonymousPrefix:
+            return MicrosoftTeamsUserIdentifier(userId: suffix, isAnonymous: true)
+        case teamUserPublicCloudPrefix:
+            return MicrosoftTeamsUserIdentifier(
+                userId: suffix,
+                isAnonymous: false,
+                rawId: rawId,
+                cloudEnvironment: .Public
+            )
+        case teamUserDODCloudPrefix:
+            return MicrosoftTeamsUserIdentifier(
+                userId: suffix,
+                isAnonymous: false,
+                rawId: rawId,
+                cloudEnvironment: .Dod
+            )
+        case teamUserGCCHCloudPrefix:
+            return MicrosoftTeamsUserIdentifier(
+                userId: suffix,
+                isAnonymous: false,
+                rawId: rawId,
+                cloudEnvironment: .Gcch
+            )
+        case "8:acs:", "8:spool:", "8:dod-acs:", "8:gcch-acs:":
+            return CommunicationUserIdentifier(rawId)
+        default:
+            return UnknownIdentifier(rawId)
+        }
+    }
+}

--- a/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
+++ b/sdk/communication/AzureCommunicationCommon/Source/CommunicationIdentifierHelper.swift
@@ -42,6 +42,10 @@ public class CommunicationIdentifierHelper: NSObject {
         let teamUserPublicCloudPrefix = "8:orgid:"
         let teamUserDODCloudPrefix = "8:dod:"
         let teamUserGCCHCloudPrefix = "8:gcch:"
+        let acsUser = "8:acs:"
+        let spoolUser = "8:spool:"
+        let dodAcsUser = "8:dod-acs:"
+        let gcchAcsUser = "8:gcch-acs:"
 
         if rawId.hasPrefix(phoneNumberPrefix) {
             let phoneNumber = "+" + rawId.dropFirst(phoneNumberPrefix.count)
@@ -80,7 +84,7 @@ public class CommunicationIdentifierHelper: NSObject {
                 rawId: rawId,
                 cloudEnvironment: .Gcch
             )
-        case "8:acs:", "8:spool:", "8:dod-acs:", "8:gcch-acs:":
+        case acsUser, spoolUser, dodAcsUser, gcchAcsUser:
             return CommunicationUserIdentifier(rawId)
         default:
             return UnknownIdentifier(rawId)

--- a/sdk/communication/AzureCommunicationCommon/Source/Identifiers.swift
+++ b/sdk/communication/AzureCommunicationCommon/Source/Identifiers.swift
@@ -169,11 +169,8 @@ import Foundation
      - Parameter isAnonymous: Set this to true if the user is anonymous:
                                 for example when joining a meeting with a share link.
      */
-    public init(userId: String, isAnonymous: Bool) {
-        self.cloudEnviroment = .Public
-        self.userId = userId
-        self.isAnonymous = isAnonymous
-        self.rawId = isAnonymous ? "8:teamsvisitor:" + userId : "8:orgid:" + userId
+    convenience init(userId: String, isAnonymous: Bool) {
+        self.init(userId: userId, isAnonymous: isAnonymous, rawId: nil, cloudEnvironment: .Public)
     }
 
     /**

--- a/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierHelperTests.swift
+++ b/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierHelperTests.swift
@@ -1,0 +1,87 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import AzureCommunicationCommon
+import XCTest
+
+class CommunicationIdentifierHelperTests: XCTestCase {
+    func test_createUnknownIdentifier() {
+        var unknownIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "some id")
+        XCTAssertTrue(unknownIdentifier.isKind(of: UnknownIdentifier.self))
+
+        unknownIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "8:not_real_scope")
+        XCTAssertTrue(unknownIdentifier.isKind(of: UnknownIdentifier.self))
+
+        unknownIdentifier = CommunicationIdentifierHelper
+            .createCommunicationIdentifier(from: "8:not_real_scope:not_real_raw_id")
+        XCTAssertTrue(unknownIdentifier.isKind(of: UnknownIdentifier.self))
+    }
+
+    func test_createPhoneNumberIdentifier() {
+        var phoneNumberIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "4:11231234")
+        XCTAssertTrue(phoneNumberIdentifier.isKind(of: PhoneNumberIdentifier.self))
+        phoneNumberIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "4:11231234:asdf")
+
+        XCTAssertTrue(phoneNumberIdentifier.isKind(of: PhoneNumberIdentifier.self))
+    }
+
+    func test_createCommunicationUserIdentifier() {
+        let acsScope = "8:acs:some_raw_id"
+        var communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: acsScope)
+        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+
+        let spoolScope = "8:spool:some_raw_id"
+        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: spoolScope)
+        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+
+        let dodAcsScope = "8:dod-acs:some_raw_id"
+        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: dodAcsScope)
+        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+
+        let gcchAcsScope = "8:gcch-acs:some_raw_id"
+        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: gcchAcsScope)
+        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+    }
+
+    func test_createMicrosoftTeamsUserIdentifier() {
+        let teamUserAnonymousScope = "8:teamsvisitor:some_raw_id"
+        var teamUserIdentifier = CommunicationIdentifierHelper
+            .createCommunicationIdentifier(from: teamUserAnonymousScope)
+        XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+
+        let teamUserPublicCloudScope = "8:orgid:some_raw_id"
+        teamUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: teamUserPublicCloudScope)
+        XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+
+        let teamUserDODCloudScope = "8:dod:some_raw_id"
+        teamUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: teamUserDODCloudScope)
+        XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+
+        let teamUserGCCHCloudScope = "8:gcch:some_raw_id"
+        teamUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: teamUserGCCHCloudScope)
+        XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+    }
+}

--- a/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierHelperTests.swift
+++ b/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierHelperTests.swift
@@ -29,59 +29,130 @@ import XCTest
 
 class CommunicationIdentifierHelperTests: XCTestCase {
     func test_createUnknownIdentifier() {
-        var unknownIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "some id")
+        var unknownIdentifier = CommunicationIdentifierHelper
+            .createCommunicationIdentifier(from: "37691ec4-57fb-4c0f-ae31-32791610cb14")
         XCTAssertTrue(unknownIdentifier.isKind(of: UnknownIdentifier.self))
-
-        unknownIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "8:not_real_scope")
-        XCTAssertTrue(unknownIdentifier.isKind(of: UnknownIdentifier.self))
+        XCTAssertEqual(unknownIdentifier.rawId, "37691ec4-57fb-4c0f-ae31-32791610cb14")
 
         unknownIdentifier = CommunicationIdentifierHelper
-            .createCommunicationIdentifier(from: "8:not_real_scope:not_real_raw_id")
+            .createCommunicationIdentifier(from: "48:37691ec4-57fb-4c0f-ae31-32791610cb14")
         XCTAssertTrue(unknownIdentifier.isKind(of: UnknownIdentifier.self))
+        XCTAssertEqual(unknownIdentifier.rawId, "48:37691ec4-57fb-4c0f-ae31-32791610cb14")
     }
 
     func test_createPhoneNumberIdentifier() {
-        var phoneNumberIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "4:11231234")
+        let phoneNumberRawId = "4:12345556789"
+        let phoneNumberIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: phoneNumberRawId)
         XCTAssertTrue(phoneNumberIdentifier.isKind(of: PhoneNumberIdentifier.self))
-        phoneNumberIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: "4:11231234:asdf")
-
-        XCTAssertTrue(phoneNumberIdentifier.isKind(of: PhoneNumberIdentifier.self))
+        XCTAssertEqual((phoneNumberIdentifier as? PhoneNumberIdentifier)?.rawId, phoneNumberRawId)
+        XCTAssertEqual((phoneNumberIdentifier as? PhoneNumberIdentifier)?.phoneNumber, "+12345556789")
     }
 
     func test_createCommunicationUserIdentifier() {
-        let acsRawId = "8:acs:some_raw_id"
-        var communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: acsRawId)
-        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        let acsRawId = "8:acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        var communicationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: acsRawId)
+        XCTAssertTrue(communicationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        XCTAssertEqual(communicationUserIdentifier.rawId, acsRawId)
+        XCTAssertEqual(
+            (communicationUserIdentifier as? CommunicationUserIdentifier)?.identifier, acsRawId
+        )
 
-        let spoolRawId = "8:spool:some_raw_id"
-        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: spoolRawId)
-        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        let spoolRawId = "8:spool:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        communicationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: spoolRawId)
+        XCTAssertTrue(communicationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        XCTAssertEqual(communicationUserIdentifier.rawId, spoolRawId)
+        XCTAssertEqual(
+            (communicationUserIdentifier as? CommunicationUserIdentifier)?.identifier, spoolRawId
+        )
 
-        let dodAcsRawId = "8:dod-acs:some_raw_id"
-        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: dodAcsRawId)
-        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        let dodAcsRawId = "8:dod-acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        communicationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: dodAcsRawId)
+        XCTAssertTrue(communicationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        XCTAssertEqual(communicationUserIdentifier.rawId, dodAcsRawId)
+        XCTAssertEqual(
+            (communicationUserIdentifier as? CommunicationUserIdentifier)?.identifier, dodAcsRawId
+        )
 
-        let gcchAcsRawId = "8:gcch-acs:some_raw_id"
-        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: gcchAcsRawId)
-        XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        let gcchAcsRawId = "8:gcch-acs:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        communicationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: gcchAcsRawId)
+        XCTAssertTrue(communicationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
+        XCTAssertEqual(communicationUserIdentifier.rawId, gcchAcsRawId)
+        XCTAssertEqual(
+            (communicationUserIdentifier as? CommunicationUserIdentifier)?.identifier, gcchAcsRawId
+        )
     }
 
-    func test_createMicrosoftTeamsUserIdentifier() {
-        let teamUserAnonymousScope = "8:teamsvisitor:some_raw_id"
-        var teamUserIdentifier = CommunicationIdentifierHelper
+    func test_createMicrosoftTeamsUserIdentifierAnonymousScope() {
+        let teamUserAnonymousScope =
+            "8:teamsvisitor:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        let teamUserIdentifier = CommunicationIdentifierHelper
             .createCommunicationIdentifier(from: teamUserAnonymousScope)
         XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+        XCTAssertEqual(teamUserIdentifier.rawId, teamUserAnonymousScope)
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.userId,
+            "37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.isAnonymous, true
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.cloudEnviroment, .Public
+        )
+    }
 
-        let teamUserPublicCloudScope = "8:orgid:some_raw_id"
-        teamUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: teamUserPublicCloudScope)
+    func test_createMicrosoftTeamsUserIdentifierPublicScope() {
+        let teamUserPublicCloudScope =
+            "8:orgid:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        let teamUserIdentifier = CommunicationIdentifierHelper
+            .createCommunicationIdentifier(from: teamUserPublicCloudScope)
         XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+        XCTAssertEqual(teamUserIdentifier.rawId, teamUserPublicCloudScope)
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.userId,
+            "37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.isAnonymous, false
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.cloudEnviroment, .Public
+        )
+    }
 
-        let teamUserDODCloudScope = "8:dod:some_raw_id"
-        teamUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: teamUserDODCloudScope)
+    func test_createMicrosoftTeamsUserIdentifierDODScope() {
+        let teamUserDODCloudScope = "8:dod:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        let teamUserIdentifier = CommunicationIdentifierHelper
+            .createCommunicationIdentifier(from: teamUserDODCloudScope)
         XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+        XCTAssertEqual(teamUserIdentifier.rawId, teamUserDODCloudScope)
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.userId,
+            "37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.isAnonymous, false
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.cloudEnviroment, .Dod
+        )
+    }
 
-        let teamUserGCCHCloudScope = "8:gcch:some_raw_id"
-        teamUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: teamUserGCCHCloudScope)
+    func test_createMicrosoftTeamsUserIdentifierGCCHScope() {
+        let teamUserGCCHCloudScope = "8:gcch:37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        let teamUserIdentifier = CommunicationIdentifierHelper
+            .createCommunicationIdentifier(from: teamUserGCCHCloudScope)
         XCTAssertTrue(teamUserIdentifier.isKind(of: MicrosoftTeamsUserIdentifier.self))
+        XCTAssertEqual(teamUserIdentifier.rawId, teamUserGCCHCloudScope)
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.userId,
+            "37691ec4-57fb-4c0f-ae31-32791610cb14_37691ec4-57fb-4c0f-ae31-32791610cb14"
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.isAnonymous, false
+        )
+        XCTAssertEqual(
+            (teamUserIdentifier as? MicrosoftTeamsUserIdentifier)?.cloudEnviroment, .Gcch
+        )
     }
 }

--- a/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierHelperTests.swift
+++ b/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierHelperTests.swift
@@ -49,20 +49,20 @@ class CommunicationIdentifierHelperTests: XCTestCase {
     }
 
     func test_createCommunicationUserIdentifier() {
-        let acsScope = "8:acs:some_raw_id"
-        var communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: acsScope)
+        let acsRawId = "8:acs:some_raw_id"
+        var communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: acsRawId)
         XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
 
-        let spoolScope = "8:spool:some_raw_id"
-        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: spoolScope)
+        let spoolRawId = "8:spool:some_raw_id"
+        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: spoolRawId)
         XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
 
-        let dodAcsScope = "8:dod-acs:some_raw_id"
-        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: dodAcsScope)
+        let dodAcsRawId = "8:dod-acs:some_raw_id"
+        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: dodAcsRawId)
         XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
 
-        let gcchAcsScope = "8:gcch-acs:some_raw_id"
-        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: gcchAcsScope)
+        let gcchAcsRawId = "8:gcch-acs:some_raw_id"
+        communciationUserIdentifier = CommunicationIdentifierHelper.createCommunicationIdentifier(from: gcchAcsRawId)
         XCTAssertTrue(communciationUserIdentifier.isKind(of: CommunicationUserIdentifier.self))
     }
 

--- a/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierTest.swift
+++ b/sdk/communication/AzureCommunicationCommon/Tests/CommunicationIdentifierTest.swift
@@ -36,53 +36,92 @@ class CommunicationIdentifierTest: XCTestCase {
     let testPhoneNumber = "+12223334444"
     let testTeamsUserId = "Microsoft Teams User Id"
 
-    func test_IfIdIsOptional_EqualityOnlyTestIfPresentOnBothSide() throws {
-        XCTAssertTrue(
+    func test_CommunicationUserIdentifier_RawId_IsEqualTo_Identifier() {
+        let userIdentifier = CommunicationUserIdentifier(testRawId)
+        XCTAssertEqual(userIdentifier.rawId, userIdentifier.identifier)
+    }
+
+    func test_UnknownIdentifier_RawId_IsEqualTo_Identifier() {
+        let unknownIdentifier = UnknownIdentifier(testRawId)
+        XCTAssertEqual(unknownIdentifier.rawId, unknownIdentifier.identifier)
+    }
+
+    func test_PhoneNumberIdentifier_IfRawIdIsNull_RawIdIsGeneratedProperly() {
+        let expectedPhoneNumberRawId = "4:12223334444"
+        let phoneNumberIdentifier = PhoneNumberIdentifier(phoneNumber: testPhoneNumber)
+        XCTAssertEqual(phoneNumberIdentifier.rawId, expectedPhoneNumberRawId)
+    }
+
+    func test_MicrosoftTeamsUserIdentifier_IfRawIdIsNull_RawIdIsGeneratedProperly_AnonymousUserIsFalse() {
+        let expectedRawId = "8:orgid:User Id"
+        var teamsUserIdentifier = MicrosoftTeamsUserIdentifier(userId: testUserId)
+        XCTAssertEqual(teamsUserIdentifier.rawId, expectedRawId)
+
+        let expectedRawIdAndCloudDod = "8:dod:User Id"
+        teamsUserIdentifier = MicrosoftTeamsUserIdentifier(
+            userId: testUserId,
+            cloudEnvironment: .Dod
+        )
+        XCTAssertEqual(teamsUserIdentifier.rawId, expectedRawIdAndCloudDod)
+
+        let expectedRawIdAndCloudGcch = "8:gcch:User Id"
+        teamsUserIdentifier = MicrosoftTeamsUserIdentifier(
+            userId: testUserId,
+            cloudEnvironment: .Gcch
+        )
+        XCTAssertEqual(teamsUserIdentifier.rawId, expectedRawIdAndCloudGcch)
+
+        let expectedRawIdAndCloudPublic = "8:orgid:User Id"
+        teamsUserIdentifier = MicrosoftTeamsUserIdentifier(
+            userId: testUserId,
+            cloudEnvironment: .Public
+        )
+        XCTAssertEqual(teamsUserIdentifier.rawId, expectedRawIdAndCloudPublic)
+    }
+
+    func test_MicrosoftTeamsUserIdentifier_IfRawIdIsNull_RawIdIsGeneratedProperly_AnonymousUserIsTrue() {
+        let expectedRawId = "8:teamsvisitor:User Id"
+        let teamsUserIdentifier = MicrosoftTeamsUserIdentifier(userId: testUserId, isAnonymous: true)
+        XCTAssertEqual(teamsUserIdentifier.rawId, expectedRawId)
+    }
+
+    // swiftlint:disable function_body_length
+    func test_IfRawIdIsOptional_EqualityCheckingOnlyRawId() {
+        XCTAssertFalse(
             MicrosoftTeamsUserIdentifier(
-                userId: "user id",
+                userId: testUserId,
                 isAnonymous: true,
                 rawId: testRawId
             ) ==
                 MicrosoftTeamsUserIdentifier(
-                    userId: "user id",
+                    userId: testUserId,
                     isAnonymous: true
                 )
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             MicrosoftTeamsUserIdentifier(
-                userId: "user id",
+                userId: testUserId,
                 isAnonymous: true
             ) ==
                 MicrosoftTeamsUserIdentifier(
-                    userId: "user id",
-                    isAnonymous: true
-                )
-        )
-        XCTAssertTrue(
-            MicrosoftTeamsUserIdentifier(
-                userId: "user id",
-                isAnonymous: true
-            ) ==
-                MicrosoftTeamsUserIdentifier(
-                    userId: "user id",
+                    userId: testUserId,
                     isAnonymous: true,
                     rawId: testRawId
                 )
         )
         XCTAssertFalse(
             MicrosoftTeamsUserIdentifier(
-                userId: "user id",
+                userId: testUserId,
                 isAnonymous: true,
                 rawId: "some id"
             ) ==
                 MicrosoftTeamsUserIdentifier(
-                    userId: "user id",
+                    userId: testUserId,
                     isAnonymous: true,
                     rawId: testRawId
                 )
         )
-
-        XCTAssertTrue(
+        XCTAssertFalse(
             PhoneNumberIdentifier(
                 phoneNumber: testPhoneNumber,
                 rawId: testRawId
@@ -93,7 +132,7 @@ class CommunicationIdentifierTest: XCTestCase {
             PhoneNumberIdentifier(phoneNumber: testPhoneNumber) ==
                 PhoneNumberIdentifier(phoneNumber: testPhoneNumber)
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             PhoneNumberIdentifier(phoneNumber: testPhoneNumber) ==
                 PhoneNumberIdentifier(
                     phoneNumber: testPhoneNumber,
@@ -112,11 +151,13 @@ class CommunicationIdentifierTest: XCTestCase {
         )
     }
 
+    // swiftlint:enable function_body_length
+
     func test_MicrosoftTeamsUserIdentifier_DefaultCloudIsPublic() throws {
         XCTAssertEqual(
             CommunicationCloudEnvironment.Public,
             MicrosoftTeamsUserIdentifier(
-                userId: "user id",
+                userId: testUserId,
                 isAnonymous: true,
                 rawId: testRawId
             ).cloudEnviroment


### PR DESCRIPTION
The `CommunicationIdentifier` design provides a good abstraction of Azure Communication Services internal id format with better type safety, auto-complete and hides internal knowledge.

Create new `rawId` in `CommunicationIdentifier` protocol 
Introduce `CommunicationIdentifierHelper` help deserialize the mri and convenient way to create appropriate identifiers

Details [Internal wiki](https://skype.visualstudio.com/SPOOL/_wiki/wikis/SPOOL.wiki/31075/Design-change-request-RawId-support-for-(de)serialization)