### PR TITLE
Add default .assets directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ fastlane/test_output
 Icon?
 *.bak
 test-settings.plist
+
+# Default Assets restore directory
+.assets
+


### PR DESCRIPTION
The default assets restore is a `.assets` directory in the repository root. This directory needs to be ignored by each individual langue.