### PR TITLE
A patch release for AzureCommunicationCommon 1.1.1

### DIFF
--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCommunicationCommon",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "summary": "Azure Communication Service common client library for iOS",
   "description": "This package contains common code for Azure Communication Services\nlibraries.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureCommunicationCommon_1.1.0"
+    "tag": "AzureCommunicationCommon_1.1.1"
   },
   "source_files": "sdk/communication/AzureCommunicationCommon/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
@@ -545,7 +545,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -577,7 +577,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 1.1.0 (upcoming)
+## 1.1.1 (2022-11-17)
+### Bugs fixed
+- Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading + sign or not.
+
+## 1.1.0 (2022-09-08)
 ### New Features
 - Introduce new `createCommunicationIdentifier(from: )` to translate between a CommunicationIdentifier and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
 - Introduce new `rawId` getter property in the `CommunicationIdentifier` protocol to return rawId representation.


### PR DESCRIPTION
- Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading + sign or not.