### PR TITLE
[Feature] Provide async wrappers for PagedCollection

### DIFF
--- a/sdk/core/AzureCore/CHANGELOG.md
+++ b/sdk/core/AzureCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.16 
+## 1.0.0-beta.16 (Unreleased)
 ### New Features
 - Added async wrappers to PageCollection nextPage and nextItem
 

--- a/sdk/core/AzureCore/CHANGELOG.md
+++ b/sdk/core/AzureCore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0-beta.16 
+### New Features
+- Added async wrappers to PageCollection nextPage and nextItem
+
 ## 1.0.0-beta.15 (2022-03-08)
 ### Bugs Fixed
 - Fixed issue where pipeline calls multiple callback if a bad status code was received.

--- a/sdk/core/AzureCore/Source/DataStructures/Collections.swift
+++ b/sdk/core/AzureCore/Source/DataStructures/Collections.swift
@@ -256,6 +256,16 @@ public class PagedCollection<SingleElement: Codable> {
         }
     }
 
+    @available(iOS 13.0.0, *)
+    /// Retrieves the next page of results asynchronously.
+    public func nextPage() async throws -> [SingleElement] {
+        try await withCheckedThrowingContinuation { continuation in
+            nextPage { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
     /// Retrieves the next item in the collection, automatically fetching new pages when needed.
     public func nextItem(completionHandler: @escaping Continuation<SingleElement>) {
         guard let pageItems = pageItems else {
@@ -280,6 +290,16 @@ public class PagedCollection<SingleElement: Codable> {
             }
         }
     }
+
+    @available(iOS 13.0.0, *)
+    public func nextItem() async throws -> SingleElement {
+        return try await withCheckedThrowingContinuation { continuation in
+            nextItem() { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
 
     public func forEachPage(progressHandler: @escaping (Element) -> Bool) {
         let dispatchQueue = client.commonOptions.dispatchQueue ?? DispatchQueue(label: "ForEachPage", qos: .utility)


### PR DESCRIPTION
With swift `async/await` available in more recent versions of iOS, we can benefit from async wrappers at the core level in other components.

This PR introduces minimal functionality to address async paging of results.