### PR TITLE
[ios] AzureCommunicationCommon 1.2.0-beta.1 release

### DIFF
--- a/jazzy/AzureCommunicationCommon.yml
+++ b/jazzy/AzureCommunicationCommon.yml
@@ -2,7 +2,7 @@ author: Microsoft
 author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure/azure-sdk-for-ios
 module: AzureCommunicationCommon
-module_version: 1.1.1
+module_version: 1.2.0-beta.1
 readme: ../sdk/communication/AzureCommunication/README.md
 skip_undocumented: false
 hide_unlisted_documentation: false

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCommunicationCommon",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "summary": "Azure Communication Service common client library for iOS",
   "description": "This package contains common code for Azure Communication Services\nlibraries.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureCommunicationCommon_1.1.1"
+    "tag": "AzureCommunicationCommon_1.2.0-beta.1"
   },
   "source_files": "sdk/communication/AzureCommunicationCommon/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0-beta.1;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -606,7 +606,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0-beta.1;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0-beta.1 (upcoming)
+## 1.2.0-beta.1 (2023-04-11)
 ### Features Added
 - Optimization added: When the proactive refreshing is enabled and the token refresher fails to provide a token that's not about to expire soon, the subsequent refresh attempts will be scheduled for when the token reaches half of its remaining lifetime until a token with long enough validity (>10 minutes) is obtained.
 - Added `cancel()` to `CommunicationTokenCredential` that cancels any internal auto-refresh operation. An instance of `CommunicationTokenCredential` cannot be reused once it has been canceled, otherwise the error will be returned.


### PR DESCRIPTION
Release of the following updates:

- [[iOS] Added support for MicrosoftBotIdentifier](https://github.com/Azure/azure-sdk-for-ios/commit/e1de57197809c8a19fb43399343bfb4dcab354c3)
- [Introducing a public cancel API for the CommunicationTokenCredential](https://github.com/Azure/azure-sdk-for-ios/commit/1e7b2a6758cd354a57abbc79e5c092ae0f802cb4)
- [Added a backoff mechanism for the CommunicationTokenCredential for au…](https://github.com/Azure/azure-sdk-for-ios/commit/9ab726d216976f27f609786eee2d4113c9048aa6)