### PR TITLE
Update from machine pools from Ubuntu 18.04 to Ubuntu 20.04

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -73,8 +73,8 @@ stages:
               variables:
                 - template: ../variables/globals.yml
               pool:
-                name: azsdk-pool-mms-ubuntu-1804-general
-                vmImage: MMSUbuntu18.04
+                name: azsdk-pool-mms-ubuntu-2004-general
+                vmImage: ubuntu-20.04
               strategy:
                 runOnce:
                   deploy:


### PR DESCRIPTION
Internal Azure SDK Engineering System update of the used Ubuntu image per
- https://github.com/Azure/azure-sdk-tools/issues/5472

To determine this change, I searched for all Ubuntu 18 strings as explained in [#5472](https://github.com/Azure/azure-sdk-tools/issues/5472).