### PR TITLE
Add EUDB Compliant Support for AzureCommunicationChat

### DIFF
--- a/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterSettings.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Signaling/TrouterSettings.swift
@@ -38,8 +38,11 @@ let defaultRegistrationData: TrouterUrlRegistrationData? = TrouterUrlRegistratio
 ) as? TrouterUrlRegistrationData
 
 let defaultClientVersion: String = "1.0.0"
-let defaultTrouterHostname: String = "go.trouter.skype.com/v4/a"
-let defaultRegistrarHostnameAndBasePath: String = "edge.skype.com/registrar/prod"
+let defaultTrouterHostname: String = "go.trouter.teams.microsoft.com/v4/a"
+let defaultRegistrarHostnameAndBasePath: String = "teams.microsoft.com/registrar/prod/v3/registrations"
+
+let eudbTrouterHostname: String = "go-eu.trouter.teams.microsoft.com/v4/a";
+let eudbCountries: Set = ["europe", "france", "germany", "norway", "switzerland", "sweden"]
 
 // GCC High gov cloud URLs
 let gcchTrouterHostname: String = "go.trouter.gov.teams.microsoft.us/v4/a"
@@ -53,12 +56,18 @@ func getTrouterSettings(token: String) throws
     -> (trouterHostname: String, registrarHostnameAndBasePath: String)
 {
     let jwt = try decode(jwtToken: token)
-    if let skypeToken = jwt["skypeid"] as? String {
-        if isGcch(id: skypeToken) {
+    if let skypeId = jwt["skypeid"] as? String {
+        if isGcch(id: skypeId) {
             return (gcchTrouterHostname, gcchRegistrarHostnameAndBasePath)
         }
-        if isDod(id: skypeToken) {
+        if isDod(id: skypeId) {
             return (dodTrouterHostname, dodRegistrarHostnameAndBasePath)
+        }
+    }
+
+    if let resourceLocation = jwt["resourceLocation"] as? String {
+        if eudbCountries.contains(resourceLocation) {
+            return (eudbTrouterHostname, defaultRegistrarHostnameAndBasePath)
         }
     }
 

--- a/sdk/communication/AzureCommunicationChat/Tests/TestSettings.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/TestSettings.swift
@@ -32,7 +32,7 @@ class TestSettings: TestSettingsProtocol {
     var user1 = "user1"
     var user2 = "user2"
     var token: String = {
-        let fakeValue = "{\"iss\":\"ACS\",\"iat\": 1608152725,\"exp\": 1739688725,\"aud\": \"\",\"sub\": \"\"}"
+        let fakeValue = "{\"iss\":\"ACS\",\"iat\": 1608152725,\"exp\": 1739688725,\"aud\": \"\",\"sub\": \"\",\"resourceLocation\": \"unitedstates\"}"
             .base64EncodedString()
         let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." + fakeValue + ".EMS0ExXqRuobm34WKJE8mAfZ7KppU5kEHl0OFdyree8"
         return token

--- a/sdk/communication/AzureCommunicationChat/Tests/TrouterSettingsUnitTest.swift
+++ b/sdk/communication/AzureCommunicationChat/Tests/TrouterSettingsUnitTest.swift
@@ -33,6 +33,14 @@ import XCTest
 // swiftlint:disable all
 class TrouterSettingsUnitTests: XCTestCase {
     private var testSettings = TestSettings()
+    var eudbToken: String = {
+        let fakeValue =
+            "{\"iss\":\"ACS\",\"iat\": 1608152725,\"exp\": 1739688725,\"aud\": \"\",\"sub\": \"\",\"resourceLocation\": \"europe\"}"
+                .base64EncodedString()
+        let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." + fakeValue + ".EMS0ExXqRuobm34WKJE8mAfZ7KppU5kEHl0OFdyree8"
+        return token
+    }()
+
     var gcchToken: String = {
         let fakeValue =
             "{\"skypeid\":\"gcch:c17ab671\",\"iss\":\"ACS\",\"iat\": 1608152725,\"exp\": 1739688725,\"aud\": \"\",\"sub\": \"\"}"
@@ -53,6 +61,16 @@ class TrouterSettingsUnitTests: XCTestCase {
         do {
             let settings = try getTrouterSettings(token: testSettings.token)
             XCTAssertEqual(settings.trouterHostname, defaultTrouterHostname)
+            XCTAssertEqual(settings.registrarHostnameAndBasePath, defaultRegistrarHostnameAndBasePath)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func test_GetTrouterSettings_ReturnEudbServiceUrl() {
+        do {
+            let settings = try getTrouterSettings(token: eudbToken)
+            XCTAssertEqual(settings.trouterHostname, eudbTrouterHostname)
             XCTAssertEqual(settings.registrarHostnameAndBasePath, defaultRegistrarHostnameAndBasePath)
         } catch {
             XCTFail()


### PR DESCRIPTION
We've updated the Trouter endpoints for EU or non-EU based on whether the resource location is in the EUDB countries or not: ["europe", "france", "germany", "norway", "switzerland", "sweden"]
- if EU: https://go-eu.trouter.teams.microsoft.com/v4/a
- if non-EU: https://go.trouter.teams.microsoft.com/v4/a

We've also updated the registrar endpoint to the following: https://teams.microsoft.com/registrar/prod/v3/registrations