### PR TITLE
[Communication][Chat] Revert reference on .cloudEnvironment to its previous name

### DIFF
--- a/sdk/communication/AzureCommunicationChat/Source/NotificationUtils/IdentityUtil.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/NotificationUtils/IdentityUtil.swift
@@ -70,13 +70,3 @@ func isGcch(id: String) -> Bool {
     let gcchAcsUserPrefix = "gcch-acs:"
     return (id.starts(with: gcchTeamsUserPrefix) || id.starts(with: gcchAcsUserPrefix))
 }
-
-/// Parses out the id/phone number portion of a user id.
-/// - Parameters:
-///   - id: The string id.
-///   - prefix: The id prefix.
-/// - Returns: The part of the id after the prefix that corresponds to the user id or phone number of a user.
-private func parse(id: String, prefix: String) -> String {
-    let index = id.index(id.startIndex, offsetBy: prefix.count)
-    return String(id.suffix(from: index))
-}

--- a/sdk/communication/AzureCommunicationChat/Source/Serializer/IdentifierSerializer.swift
+++ b/sdk/communication/AzureCommunicationChat/Source/Serializer/IdentifierSerializer.swift
@@ -123,7 +123,7 @@ internal enum IdentifierSerializer {
                         .isAnonymous,
                     cloud: serialize(
                         cloud: teamsUser
-                            .cloudEnvironment
+                            .cloudEnviroment
                     )
                 )
             )


### PR DESCRIPTION
`.cloudEnvironment` was being introduced in AzureCommunicationCommon version `1.2.0-beta.1`. This PR reverts the reference back to `.cloudEnviroment` since AzureCommunicationChat still references AzureCommunicationCommon version `~> 1.0`. This resolves the following error in our release pipeline:
> \- ERROR | xcodebuild:  AzureCommunicationChat/sdk/communication/AzureCommunicationChat/Source/Serializer/IdentifierSerializer.swift:126:30: error: value of type 'MicrosoftTeamsUserIdentifier' has no member 'cloudEnvironment'