### PR TITLE
Remove the invalid path entry sdk/storage entry from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,9 +28,6 @@
 # PRLabel: %Azure.Core
 /sdk/core/                                          @tjprescott @mpodwysocki
 
-# PRLabel: %Storage
-/sdk/storage/                                       @tjprescott @mpodwysocki
-
 # PRLabel: %Communication
 /sdk/communication/                                 @Azure/azure-sdk-communication-code-reviewers
 


### PR DESCRIPTION

sdk/storage was removed from the repository with this [PR](https://github.com/Azure/azure-sdk-for-ios/pull/1336) on Aug 16th, 2022 but the entry wasn't.