### PR TITLE
Fix for "supports docs-only Jazzy and adds Vision docs (#1664)" commit

### DIFF
--- a/jazzy/AzureAIVisionCore.yml
+++ b/jazzy/AzureAIVisionCore.yml
@@ -3,4 +3,5 @@ author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure-Samples/azure-ai-vision-sdk
 module: AzureAIVisionCore
 ref: docs/ios/AzureAIVisionCore/0.16.0-beta.1
+no_jazzy_mode: pre-generated
 output: ../build/jazzy/AzureAIVisionCore

--- a/jazzy/AzureAIVisionFace.yml
+++ b/jazzy/AzureAIVisionFace.yml
@@ -3,4 +3,5 @@ author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure-Samples/azure-ai-vision-sdk
 module: AzureAIVisionFace
 ref: docs/ios/AzureAIVisionFace/0.16.0-beta.1
+no_jazzy_mode: pre-generated
 output: ../build/jazzy/AzureAIVisionFace


### PR DESCRIPTION
Adding missing property to enable doc-only jazzy uploads.