### PR TITLE
GA release for AzureCommunicationCommon 1.2.0

### DIFF
--- a/jazzy/AzureCommunicationCommon.yml
+++ b/jazzy/AzureCommunicationCommon.yml
@@ -2,7 +2,7 @@ author: Microsoft
 author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure/azure-sdk-for-ios
 module: AzureCommunicationCommon
-module_version: 1.2.0-beta.1
+module_version: 1.2.0
 readme: ../sdk/communication/AzureCommunication/README.md
 skip_undocumented: false
 hide_unlisted_documentation: false

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCommunicationCommon",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0",
   "summary": "Azure Communication Service common client library for iOS",
   "description": "This package contains common code for Azure Communication Services\nlibraries.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureCommunicationCommon_1.2.0-beta.1"
+    "tag": "AzureCommunicationCommon_1.2.0"
   },
   "source_files": "sdk/communication/AzureCommunicationCommon/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
@@ -573,7 +573,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0-beta.1;
+				MARKETING_VERSION = 1.2.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -605,7 +605,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0-beta.1;
+				MARKETING_VERSION = 1.2.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (upcoming)
+## 1.2.0 (2024-02-23)
 ### Features Added
 - Added support for a new communication identifier `MicrosoftTeamsAppIdentifier`. It will impact any code that previously depended on the use of `UnknownIdentifier` with rawIDs starting with `28:orgid:`, `28:dod:`, or `28:gcch:`.
 


### PR DESCRIPTION
Added support for a new communication identifier `MicrosoftTeamsAppIdentifier`. It will impact any code that previously depended on the use of `UnknownIdentifier` with rawIDs starting with `28:orgid:`, `28:dod:`, or `28:gcch:`.