### PR TITLE
Update CODEOWNERS for eng/common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,3 +37,4 @@
 # Eng Sys
 ###########
 /eng/                                               @benbp @weshaggard
+/eng/common/                                        @Azure/azure-sdk-eng


### PR DESCRIPTION
Add engsys team as owner for files under eng/common to enable engsys team to be able to approve and merge eng/common sync PRs.