### PR TITLE
Update Common Package Version

### DIFF
--- a/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
+++ b/sdk/communication/AzureCommunicationChat/AzureCommunicationChat.podspec.json
@@ -29,7 +29,7 @@
       "1.0.0-beta.15"
     ],
     "AzureCommunicationCommon": [
-      "~> 1.0"
+      "~> 1.2.0"
     ],
     "Trouter": [
       "0.2.0"

--- a/sdk/communication/AzureCommunicationChat/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationChat/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.3.5 (2024-06-13)
+Updated AzureCommunicationCommon package version to 1.2.0.
+
 ## 1.3.4 (2024-03-05)
 ### Bugs Fixed
 - The SDK now incorporates a more recent Trouter template to prevent IOS devices from receiving duplicate real-time notifications.


### PR DESCRIPTION
This PR is used to update AzureCommunicationCommon Package to 1.2.0.
All existing functionalities, including real-time notification and push notification, work well after the change.