### PR TITLE
Releasing ACS iOS SDK 2.13.0

### DIFF
--- a/sdk/communication/AzureCommunicationCalling/AzureCommunicationCalling.podspec.json
+++ b/sdk/communication/AzureCommunicationCalling/AzureCommunicationCalling.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCommunicationCalling",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "summary": "Azure Communication Calling Service client library for iOS",
   "description": "This package contains the Calling client library for Azure Communication\nServices.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -17,7 +17,7 @@
   },
   "swift_versions": "5.0",
   "source": {
-    "http": "https://github.com/Azure/Communication/releases/download/v2.12.1/AzureCommunicationCalling-2.12.1.zip"
+    "http": "https://github.com/Azure/Communication/releases/download/v2.13.0/AzureCommunicationCalling-2.13.0.zip"
   },
   "source_files": "AzureCommunicationCalling.xcframework/*/AzureCommunicationCalling.framework/Headers/*.h",
   "public_header_files": "AzureCommunicationCalling.xcframework/*/AzureCommunicationCalling.framework/Headers/*.h",

--- a/sdk/communication/AzureCommunicationCalling/AzureCommunicationCalling.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationCalling/AzureCommunicationCalling.xcodeproj/project.pbxproj
@@ -275,7 +275,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "2.12.1";
+				MARKETING_VERSION = "2.13.0";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.AzureCommunicationCalling;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -300,7 +300,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "2.12.1";
+				MARKETING_VERSION = "2.13.0";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.AzureCommunicationCalling;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/sdk/communication/AzureCommunicationCalling/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCalling/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 2.13.0 (2024-09-23)
+### Features Added
+* Added support for`Soft Mute` feature.
+
 ## 2.12.1 (2024-09-19)
 ### Bugs Fixed
 * Fixed a crash issue to ensure compatibility with Xcode 16.


### PR DESCRIPTION
Releasing ACS iOS SDK 2.13.0 GA:

ApiView:
https://apiview.dev/Assemblies/Review/80768c5191c748a69f83e4e2d42bd97d/304bf3f9e7614fcf94578742520e09fc?diffRevisionId=981b99428ec7401380091ddf67966891&doc=False&diffOnly=True