### PR TITLE
Revert "Filter out Excludes for PR Pipelines (#1982)"

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -14,9 +14,6 @@ parameters:
   - name: ScriptDirectory
     type: string
     default: eng/common/scripts
-  - name: ExcludePaths
-    type: object
-    default: []
 
 steps:
   # There will be transitory period for every language repo where the <language> - pullrequest build definition will run
@@ -29,12 +26,10 @@ steps:
       - task: Powershell@2
         displayName: Generate PR Diff
         inputs:
-          targetType: inline
-          script: >
-            ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
+          filePath: ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
+          arguments: >
             -TargetPath '${{ parameters.TargetPath }}'
             -ArtifactPath '${{ parameters.DiffDirectory }}'
-            -ExcludePaths ('${{ convertToJson(parameters.ExcludePaths) }}' | convertFrom-Json)
           pwsh: true
 
       # When running in PR mode, we want the detected changed services to be attached to the build as tags.

--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -16,10 +16,7 @@ Param (
   [Parameter(Mandatory = $True)]
   [string] $ArtifactPath,
   [Parameter(Mandatory = $True)]
-  [string] $TargetPath,
-  [Parameter(Mandatory=$false)]
-  [AllowEmptyCollection()]
-  [array] $ExcludePaths
+  [string] $TargetPath
 )
 
 . (Join-Path $PSScriptRoot "Helpers" "git-helpers.ps1")
@@ -48,21 +45,13 @@ $changedFiles = @()
 $changedServices = @()
 
 $changedFiles = Get-ChangedFiles -DiffPath $TargetPath
-
 if ($changedFiles) {
   $changedServices = Get-ChangedServices -ChangedFiles $changedFiles
 }
 
-# ExcludePaths is an object array with the default of [] which evaluates to null.
-# If the value is null, set it to empty list to ensure that the empty list is
-# stored in the json
-if (-not $ExcludePaths) {
-  $ExcludePaths = @()
-}
 $result = [PSCustomObject]@{
   "ChangedFiles"    = $changedFiles
   "ChangedServices" = $changedServices
-  "ExcludePaths"    = $ExcludePaths
   "PRNumber"        = if ($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) { $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER } else { "-1" }
 }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -162,13 +162,6 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     $allPackageProperties = Get-AllPkgProperties
     $diff = Get-Content $InputDiffJson | ConvertFrom-Json
     $targetedFiles = $diff.ChangedFiles
-    # The exclude paths and the targeted files paths aren't full OS paths, they're
-    # GitHub paths meaning they're relative to the repo root and slashes are forward
-    # slashes "/". The ExcludePaths need to have a trailing slash added in order
-    # correctly test for string matches without overmatching. For example, if a pr
-    # had files sdk/foo/file1 and sdk/foobar/file2 with the exclude of anything in
-    # sdk/foo, it should only exclude things under sdk/foo.
-    $excludePaths = $diff.ExcludePaths | ForEach-Object { $_ + "/" }
 
     $additionalValidationPackages = @()
     $lookup = @{}
@@ -179,16 +172,6 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         $lookup[$lookupKey] = $pkg
 
         foreach ($file in $targetedFiles) {
-            $shouldExclude = $false
-            foreach ($exclude in $excludePaths) {
-                if ($file.StartsWith($exclude,'CurrentCultureIgnoreCase')) {
-                    $shouldExclude = $true
-                    break
-                }
-            }
-            if ($shouldExclude) {
-                continue
-            }
             $filePath = (Join-Path $RepoRoot $file)
             $shouldInclude = $filePath -like (Join-Path "$pkgDirectory" "*")
             if ($shouldInclude) {


### PR DESCRIPTION
This reverts commit f7291906a46ee5159a7bdf3f543c916bf3e7b5ae.

Reverting, merged too soon and have to make updates.