### PR TITLE
Fix Xcode 16.3 '==' operator compatibility for RequestStringConvertible

### DIFF
--- a/sdk/core/AzureCore/Source/Util/RequestString.swift
+++ b/sdk/core/AzureCore/Source/Util/RequestString.swift
@@ -32,7 +32,7 @@ public protocol RequestStringConvertible {
 }
 
 public extension RequestStringConvertible {
-    static func == (lhs: RequestStringConvertible, rhs: RequestStringConvertible) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.requestString == rhs.requestString
     }
 }


### PR DESCRIPTION
# Summary
Fixes Xcode's 16.3 compatibility issue by updating the == operator in the RequestStringConvertible protocol extension to use Self instead of the protocol type.

# Motivation
In Xcode 16.3, operator overloads in protocol extensions must use Self to avoid ambiguity. The original code causes a compile-time error:

`Member operator '==' must have at least one argument of type 'Self'`

![Screenshot 2025-04-01 at 1 06 49 AM](https://github.com/user-attachments/assets/23471faa-4d0d-450e-8999-dba9e176fb22)


# Changes
Updated static func == (lhs: RequestStringConvertible, rhs: RequestStringConvertible)
to static func == (lhs: Self, rhs: Self)

# Testing
Verified that this change compiles and works correctly under Xcode 16.3.

Confirmed no regression under earlier Swift versions.

Please let me know if there’s any additional context or backward compatibility concerns to consider.