### PR TITLE
Release updates for AzureCommunicationCommon 1.3.0

### DIFF
--- a/jazzy/AzureCommunicationCommon.yml
+++ b/jazzy/AzureCommunicationCommon.yml
@@ -2,7 +2,7 @@ author: Microsoft
 author_url: https://azure.github.io/azure-sdk/
 github_url: https://github.com/Azure/azure-sdk-for-ios
 module: AzureCommunicationCommon
-module_version: 1.2.0
+module_version: 1.3.0
 readme: ../sdk/communication/AzureCommunication/README.md
 skip_undocumented: false
 hide_unlisted_documentation: false

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCommunicationCommon",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "summary": "Azure Communication Service common client library for iOS",
   "description": "This package contains common code for Azure Communication Services\nlibraries.",
   "homepage": "https://github.com/Azure/azure-sdk-for-ios",
@@ -18,7 +18,7 @@
   "swift_versions": "5.0",
   "source": {
     "git": "https://github.com/Azure/azure-sdk-for-ios.git",
-    "tag": "AzureCommunicationCommon_1.2.0"
+    "tag": "AzureCommunicationCommon_1.3.0"
   },
   "source_files": "sdk/communication/AzureCommunicationCommon/Source/**/*.{swift,h,m}",
   "pod_target_xcconfig": {

--- a/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
+++ b/sdk/communication/AzureCommunicationCommon/AzureCommunicationCommon.xcodeproj/project.pbxproj
@@ -588,7 +588,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -620,7 +620,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				NEW_SETTING = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.communication.AzureCommunicationCommon;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
+++ b/sdk/communication/AzureCommunicationCommon/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.3.0 (Unreleased)
+## 1.3.0 (2025-06-09)
 ### Features Added
 - Added support for a new communication identifier `TeamsExtensionUserIdentifier` which maps rawIds with format `8:acs:{resourceId}_{tenantId}_{userId}`.
 - Added `isAnonymous` and `assertedId` properties to `PhoneNumberIdentifier`.

--- a/sdk/communication/AzureCommunicationCommon/README.md
+++ b/sdk/communication/AzureCommunicationCommon/README.md
@@ -92,7 +92,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'MyTarget' do
-  pod 'AzureCommunicationCommon', '1.2.0'
+  pod 'AzureCommunicationCommon', '1.3.0'
   ...
 end
 ```


### PR DESCRIPTION
This PR includes the following changes:
* Release updates for AzureCommunicationCommon 1.3.0
* The TeamsExtensionUserIdentifier and PhoneNumberIdentifier changes will be released