### PR TITLE
Remove path filters from `sdk/core/ci.yml`

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -5,10 +5,6 @@ trigger:
     - main
     - hotfix/*
     - release/*
-  paths:
-    include:
-    - sdk/core/
-    - sdk/eng/
 
 pr:
   branches:
@@ -17,10 +13,6 @@ pr:
     - feature/*
     - hotfix/*
     - release/*
-  paths:
-    include:
-    - sdk/core/
-    - sdk/eng/
 
 resources:
   repositories:


### PR DESCRIPTION
So that triggers in all cases. Related to Azure/azure-sdk-tools#15160