### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/templates/stages/archetype-ios-release.yml
+++ b/eng/pipelines/templates/stages/archetype-ios-release.yml
@@ -57,6 +57,7 @@ stages:
                   ArtifactLocation: $(System.DefaultWorkingDirectory)/sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}
                   PackageRepository: CocoaPods
                   ReleaseSha: $(Build.SourceVersion)
+                  AuthToken: ''
 
           - ${{if ne(artifact.skipCocoaPods, 'true')}}:
             - job: PublishPackageToCocoaPodsTrunk       


### PR DESCRIPTION
This pull request introduces a minor change to the iOS release pipeline configuration by adding an explicit empty `AuthToken` parameter. This helps clarify the pipeline's expectations for authentication tokens, likely to avoid unintended behavior or misconfiguration.

* Pipeline configuration:
  * [`eng/pipelines/templates/stages/archetype-ios-release.yml`](diffhunk://#diff-b5487e71c854c31aa59c9c734085bf9a9031489d93fc343357aff7eb6654ee01R60): Added an explicit `AuthToken: ''` parameter to the CocoaPods publishing step.

Related to Azure/azure-sdk-tools#9842

[ios - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6372516&view=results)