### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,4 +38,5 @@
 /.config/1espt/                                     @benbp @weshaggard
 /.github/workflows/                                 @Azure/azure-sdk-eng
 /.github/CODEOWNERS                                 @tjprescott @Azure/azure-sdk-eng
+/.github/skills/                                    @Azure/azsdk-cli
 /eng/common/pipelines/codeowners-linter.yml         @tjprescott


### PR DESCRIPTION
Adds a CODEOWNERS entry assigning ownership of skill definitions under `.github/skills/` to the `@azure/azsdk-cli` team.

The entry is grouped with the other `.github/` paths in the Eng Sys section to follow the file's existing conventions.