### PR TITLE
Remove link verification from ci job

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -139,11 +139,6 @@ jobs:
       - script: sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app
         displayName: 'Use Xcode $(XcodeVersion)'
 
-      - template: ../../../common/pipelines/templates/steps/verify-links.yml
-        parameters:
-          Directory: ""
-          CheckLinkGuidance: $true
-
       - script: |
           python ./eng/scripts/version.py verify
         displayName: Verify Versions


### PR DESCRIPTION
This pull request makes a small change to the `archetype-sdk-client.yml` pipeline template by removing the step that verifies links. The verification of versions step remains unchanged.

* Removed the inclusion of the `verify-links.yml` template, which previously checked for broken links in the codebase.